### PR TITLE
Add emoji cleaner to 2.5 voice service

### DIFF
--- a/PROMPTY_2.5/services/asistente_voz.py
+++ b/PROMPTY_2.5/services/asistente_voz.py
@@ -1,6 +1,7 @@
 import speech_recognition as sr
 import pyttsx3
 from services.permisos import Permisos
+from utils.helpers import quitar_colores, limpiar_emoji
 
 class ServicioVoz:
     def __init__(self, usuario, verificar_admin_callback=None):
@@ -19,8 +20,11 @@ class ServicioVoz:
         self.engine.setProperty("volume", self.volumen)
 
     def hablar(self, texto):
-        self.engine.say(texto)
+        texto_sin_colores = quitar_colores(texto)
+        texto_limpio = limpiar_emoji(texto_sin_colores)
+        self.engine.say(texto_limpio)
         self.engine.runAndWait()
+        return texto_limpio
 
     def escuchar(self):
         """Escucha desde el micrófono y devuelve el texto reconocido.

--- a/PROMPTY_2.5/utils/helpers.py
+++ b/PROMPTY_2.5/utils/helpers.py
@@ -32,3 +32,7 @@ def guardar_datos(ruta, lista):
     with open(ruta, "w", encoding="utf-8") as f:
         for linea in lista:
             f.write(f"{linea}\n")
+
+def limpiar_emoji(texto):
+    """Elimina emojis u otros caracteres no alfanuméricos para reproducir por voz."""
+    return re.sub(r'[^\w\s.,;:!?()\'\"-]', '', texto or "")


### PR DESCRIPTION
## Summary
- add `limpiar_emoji` helper to remove emojis
- sanitize spoken text using the new helper in `ServicioVoz.hablar`

## Testing
- `python -m py_compile PROMPTY_2.5/utils/helpers.py PROMPTY_2.5/services/asistente_voz.py`
- `python PROMPTY_2.5/main.py` *(fails: ModuleNotFoundError: No module named 'speech_recognition')*

------
https://chatgpt.com/codex/tasks/task_e_6845042ca7ec8332b0e9b377ee03b5ab