### PR TITLE
Fix speech recognition package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-speech_recognition
+SpeechRecognition
 pyttsx3
 colorama

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='2.5.0',
     packages=find_packages(include=['prompty', 'prompty.*']),
     install_requires=[
-        'speech_recognition',
+        'SpeechRecognition',
         'pyttsx3',
         'colorama'
     ],


### PR DESCRIPTION
## Summary
- fix case for SpeechRecognition dependency in `requirements.txt`
- update `setup.py` to use correct package name

## Testing
- `python -m pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_68450d344b988332a5f1baec50e1b5d5