### PR TITLE
Improve info menu and admin user list

### DIFF
--- a/PROMPTY_2.5/services/comandos_basicos.py
+++ b/PROMPTY_2.5/services/comandos_basicos.py
@@ -141,8 +141,42 @@ class ComandosBasicos:
         if ruta is None:
             ruta = os.path.join(os.path.dirname(__file__), '..', 'data', 'info_programa.txt')
         ruta = os.path.abspath(ruta)
+
+        secciones = {
+            "1": "SOBRE LOS CREADORES DE PROMPTY",
+            "2": "SOBRE EL PROGRAMA",
+            "3": "PROCESO DE DESARROLLO",
+            "4": "LICENCIA DE USO Y DERECHOS",
+        }
+
         try:
             with open(ruta, "r", encoding="utf-8") as archivo:
-                return archivo.read()
+                lineas = archivo.readlines()
         except Exception as e:
             return f"❌ No se pudo acceder a la información del programa: {e}"
+
+        while True:
+            print("\n¿Sobre qué deseas saber?")
+            print("1. Sobre los creadores")
+            print("2. Sobre el programa")
+            print("3. Sobre el desarrollo")
+            print("4. Sobre la licencia de uso")
+            opcion = input("Selecciona una opción (1-4): ").strip()
+            titulo = secciones.get(opcion)
+            if titulo:
+                break
+            print("❌ Opción inválida.")
+
+        contenido = []
+        capturar = False
+        for linea in lineas:
+            cabecera = linea.strip()
+            if cabecera in secciones.values():
+                capturar = cabecera == titulo
+                continue
+            if capturar:
+                if cabecera in secciones.values():
+                    break
+                contenido.append(linea.rstrip())
+
+        return "\n".join(contenido).strip()

--- a/PROMPTY_2.5/services/interpretador.py
+++ b/PROMPTY_2.5/services/interpretador.py
@@ -7,11 +7,10 @@ def interpretar(texto):
         ("3", "tres"): "buscar_en_navegador",
         ("4", "cuatro"): "dato_curioso",
         ("5", "cinco"): "info_programa",
-        ("6", "seis", "salir", "cerrar"): "salir",
-        ("7", "siete", "administrador", "modo admin"): "modo_admin",
-        ("8", "ocho"): "editar_usuario",
-        ("9", "nueve", "cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
-        ("ayuda", "menu", "opciones"): "ayuda",
+        ("6", "seis", "administrador", "modo admin"): "modo_admin",
+        ("7", "siete"): "editar_usuario",
+        ("8", "ocho", "cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
+        ("10", "diez", "salir", "cerrar"): "salir",
     }
 
     for claves, comando in numero_comandos.items():
@@ -26,6 +25,7 @@ def interpretar(texto):
         ("curioso", "dato"): "dato_curioso",
         ("programa", "creador", "información"): "info_programa",
         ("usuario", "perfil"): "editar_usuario",
+        ("ayuda", "opciones", "menu"): "ayuda",
         ("salir", "cerrar"): "salir",
         ("cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
     }

--- a/PROMPTY_2.5/views/terminal.py
+++ b/PROMPTY_2.5/views/terminal.py
@@ -14,8 +14,8 @@ class VistaTerminal:
         self.modo_respuesta = "texto"
 
     def iniciar(self):
-        limpiar_pantalla()
         self.elegir_modo_respuesta()
+        limpiar_pantalla()
         print(f"\n✅ Bienvenido {self.usuario.nombre} ({self.usuario.rol})")
         self.mostrar_bienvenida()
 
@@ -138,10 +138,10 @@ class VistaTerminal:
 3. Busque algo en YouTube o en tu navegador preferido (puedes usar un término o ingresar una URL).
 4. Te comparta un dato curioso.
 5. Te hable sobre el programa y sus creadores.
-6. Salir del programa.
-7. Acceder al modo administrador (con contraseña).
-8. Modificar tus datos de usuario.
-9. Cerrar sesión para iniciar con otro usuario.
+6. Acceder al modo administrador (con contraseña).
+7. Modificar tus datos de usuario.
+8. Cerrar sesión para iniciar con otro usuario.
+10. Salir del programa.
 """)
 
     def menu_configuracion_voz(self):
@@ -234,13 +234,21 @@ class VistaTerminal:
                 )
                 print("✔ Usuario actualizado.")
             elif opcion == "3":
-                for u in self.gestor_roles.listar_usuarios():
-                    print(f"{u.cif}: {u.nombre} ({u.rol})")
+                self.mostrar_tabla_usuarios()
 
             elif opcion == "4":
                 break
             else:
                 print("❌ Opción no válida.")
+
+    def mostrar_tabla_usuarios(self):
+        usuarios = self.gestor_roles.listar_usuarios()
+        encabezado = f"{'CIF':<10} {'Nombre':<20} {'Contraseña':<64} Permisos"
+        print(encabezado)
+        print("-" * len(encabezado))
+        for u in usuarios:
+            permisos = ", ".join(u._permisos.listar_permisos(u.rol))
+            print(f"{u.cif:<10} {u.nombre:<20} {u.contrasena:<64} {permisos}")
 
     def menu_editar_usuario(self):
         while True:

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -9,6 +9,8 @@ class TestInterpretador(unittest.TestCase):
     def test_numeros(self):
         self.assertEqual(interpretar('1')[0], 'fecha_hora')
         self.assertEqual(interpretar('dos')[0], 'abrir_con_opcion')
+        self.assertEqual(interpretar('10')[0], 'salir')
+        self.assertEqual(interpretar('seis')[0], 'modo_admin')
 
     def test_palabras_clave(self):
         self.assertEqual(interpretar('abre una carpeta')[0], 'abrir_con_opcion')


### PR DESCRIPTION
## Summary
- loop until a valid option is selected when showing program info
- admin menu now displays a table with all user details
- remove numeric help menu option while keeping help command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684779de84888332b7f5d0a6c3b32fd1