### PR TITLE
Enable colorized terminal output

### DIFF
--- a/PROMPTY_2.5/__init__.py
+++ b/PROMPTY_2.5/__init__.py
@@ -1,2 +1,8 @@
 # Paquete raíz de PROMPTY 2.5
-# Contiene el asistente virtual modular con soporte de voz, roles, y comandos personalizados.
+# Contiene el asistente virtual modular con soporte de voz, roles y comandos personalizados.
+
+# Inicializar colorama para que los mensajes con colores funcionen en todos los sistemas
+from colorama import init
+
+# ``autoreset=True`` evita tener que añadir ``Style.RESET_ALL`` manualmente tras cada impresión
+init(autoreset=True)

--- a/PROMPTY_2.5/views/login.py
+++ b/PROMPTY_2.5/views/login.py
@@ -1,6 +1,7 @@
 from services.gestor_roles import GestorRoles
 from views.terminal import VistaTerminal
 from utils.helpers import limpiar_pantalla
+from colorama import Fore, Style
 
 
 class VistaLogin:
@@ -11,9 +12,9 @@ class VistaLogin:
 
     def iniciar(self):
         while True:
-            print("🔐 Iniciar sesión en PROMPTY")
-            cif = input("CIF: ").strip()
-            clave = input("Contraseña: ").strip()
+            print(f"{Fore.CYAN}🔐 Iniciar sesión en PROMPTY{Style.RESET_ALL}")
+            cif = input(f"{Fore.YELLOW}CIF:{Style.RESET_ALL} ").strip()
+            clave = input(f"{Fore.YELLOW}Contraseña:{Style.RESET_ALL} ").strip()
 
             usuario = self.gestor_roles.autenticar(cif, clave)
 
@@ -25,5 +26,5 @@ class VistaLogin:
                     continue
                 break
             else:
-                print("❌ CIF o contraseña incorrectos.")
+                print(f"{Fore.RED}❌ CIF o contraseña incorrectos.{Style.RESET_ALL}")
 


### PR DESCRIPTION
## Summary
- initialize colorama when package is imported
- display login prompts and errors in color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684786f1d038833298909a6063dc180c