### PR TITLE
Implement login GUI and role-based menus

### DIFF
--- a/PROMPTY_2.5/main.py
+++ b/PROMPTY_2.5/main.py
@@ -1,8 +1,22 @@
+"""Punto de entrada de PROMPTY 2.5."""
+
+import sys
+
 from views.login import VistaLogin
+from views.gui import LoginWindow
+from PyQt6.QtWidgets import QApplication
 
 
 def main():
-    VistaLogin().iniciar()
+    """Pregunta si se usará la interfaz de terminal o la gráfica."""
+    modo = input("¿Usar interfaz gráfica? [s/N]: ").strip().lower()
+    if modo in {"s", "y", "si", "sí"}:
+        app = QApplication(sys.argv)
+        login = LoginWindow()
+        login.show()
+        app.exec()
+    else:
+        VistaLogin().iniciar()
 
 
 if __name__ == "__main__":

--- a/PROMPTY_2.5/services/gestor_roles.py
+++ b/PROMPTY_2.5/services/gestor_roles.py
@@ -80,5 +80,17 @@ class GestorRoles:
         self.guardar_usuarios()
         return True
 
+    def restablecer_contrasena(self, cif):
+        """Genera y asigna una nueva contraseña para el usuario indicado."""
+        usuario = self.obtener_usuario_por_cif(cif)
+        if not usuario:
+            return None
+        from utils.helpers import generar_contrasena, hash_password
+
+        nueva = generar_contrasena()
+        usuario.contrasena = hash_password(nueva)
+        self.guardar_usuarios()
+        return nueva
+
     def listar_usuarios(self):
         return self.usuarios

--- a/PROMPTY_2.5/views/__init__.py
+++ b/PROMPTY_2.5/views/__init__.py
@@ -1,2 +1,2 @@
-# Vistas del sistema. En esta versión incluye la interfaz de terminal.
-# Pensado para futura integración con GUI en PROMPTY 3.0.
+# Vistas del sistema. Incluye la interfaz de terminal y una prueba de GUI
+# con pantalla de inicio de sesión.

--- a/PROMPTY_2.5/views/gui.py
+++ b/PROMPTY_2.5/views/gui.py
@@ -1,0 +1,316 @@
+import sys
+import os
+from PyQt6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QPushButton,
+    QLabel,
+    QVBoxLayout,
+    QHBoxLayout,
+    QWidget,
+    QTextEdit,
+    QLineEdit,
+    QMessageBox,
+)
+from PyQt6.QtGui import (
+    QIcon,
+    QFont,
+    QPainter,
+    QLinearGradient,
+    QBrush,
+    QPixmap,
+    QColor,
+)
+from PyQt6.QtCore import Qt, QSize
+from services.gestor_roles import GestorRoles
+
+def get_colored_icon(icon_path, color):
+    """
+    Carga el icono desde icon_path y le aplica un tinte con el color especificado.
+    Devuelve un QIcon con el icono modificado.
+    """
+    pixmap = QPixmap(icon_path)
+    if pixmap.isNull():
+        print(f"⚠ No se pudo cargar la imagen: {icon_path}")
+        return QIcon()
+    
+    # Crear un pixmap con soporte para transparencia
+    tinted = QPixmap(pixmap.size())
+    tinted.fill(Qt.GlobalColor.transparent)
+    
+    painter = QPainter(tinted)
+    painter.drawPixmap(0, 0, pixmap)
+    # Usamos el valor entero 5, que corresponde a SourceIn en Qt
+    painter.setCompositionMode(QPainter.CompositionMode(5))
+    painter.fillRect(pixmap.rect(), color)
+    painter.end()
+    
+    return QIcon(tinted)
+
+
+class ConfiguracionWindow(QWidget):
+    """Ventana secundaria para configuración."""
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Configuración")
+        self.setGeometry(150, 150, 300, 200)
+        layout = QVBoxLayout()
+        label = QLabel("Opciones de configuración en desarrollo...")
+        layout.addWidget(label)
+        boton_cerrar = QPushButton("Cerrar")
+        boton_cerrar.clicked.connect(self.close)
+        layout.addWidget(boton_cerrar)
+        self.setLayout(layout)
+
+class UsuarioWindow(QWidget):
+    """Ventana secundaria para usuario."""
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Usuario")
+        self.setGeometry(200, 200, 300, 200)
+        layout = QVBoxLayout()
+        label = QLabel("Opciones de usuario en desarrollo...")
+        layout.addWidget(label)
+        boton_cerrar = QPushButton("Cerrar")
+        boton_cerrar.clicked.connect(self.close)
+        layout.addWidget(boton_cerrar)
+        self.setLayout(layout)
+
+class AyudaWindow(QWidget):
+    """Ventana secundaria para ayuda."""
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Ayuda")
+        self.setGeometry(250, 250, 300, 200)
+        layout = QVBoxLayout()
+        label = QLabel("Opciones de ayuda en desarrollo...")
+        layout.addWidget(label)
+        boton_cerrar = QPushButton("Cerrar")
+        boton_cerrar.clicked.connect(self.close)
+        layout.addWidget(boton_cerrar)
+        self.setLayout(layout)
+
+class PROMPTYWindow(QMainWindow):
+    """Ventana principal con botones interactivos y una caja de texto para salida."""
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("PROMPTY - Asistente de Voz")
+        self.setGeometry(100, 100, 400, 600)
+        
+        # Ventanas secundarias
+        self.ventana_configuracion = None
+        self.ventana_usuario = None
+        self.ventana_ayuda = None
+        
+        # Variable para alternar entre modo oscuro y claro
+        self.dark_mode_enabled = False
+        
+        self.setup_ui()
+
+    def paintEvent(self, event):
+        """Dibuja el fondo degradado sin afectar los widgets."""
+        painter = QPainter(self)
+        gradient = QLinearGradient(0, 0, self.width(), self.height())
+        gradient.setColorAt(0, Qt.GlobalColor.blue)
+        gradient.setColorAt(1, Qt.GlobalColor.white)
+        brush = QBrush(gradient)
+        painter.fillRect(self.rect(), brush)
+
+    def setup_ui(self):
+        """Configura la interfaz con los botones en la esquina superior derecha, 
+        una etiqueta de bienvenida, el botón de micrófono y una caja de texto en la parte inferior."""
+        central_widget = QWidget(self)
+        self.setCentralWidget(central_widget)
+        main_layout = QVBoxLayout()
+        central_widget.setLayout(main_layout)
+
+        # Layout superior horizontal para los iconos de usuario, ayuda, modo oscuro y configuración
+        top_layout = QHBoxLayout()
+        top_layout.addStretch()  # Esto empuja los botones hacia la derecha
+
+        self.button_usuario = self.create_icon_button("Usuario", "usuario.png")
+        self.button_usuario.clicked.connect(self.ver_usuario)
+        top_layout.addWidget(self.button_usuario)
+
+        self.button_ayuda = self.create_icon_button("Ayuda", "ayuda.png")
+        self.button_ayuda.clicked.connect(self.ver_ayuda)
+        top_layout.addWidget(self.button_ayuda)
+
+        self.button_modo_oscuro = self.create_icon_button("Modo Oscuro", "oscuro.png")
+        self.button_modo_oscuro.clicked.connect(self.activar_modo_oscuro)
+        top_layout.addWidget(self.button_modo_oscuro)
+
+        self.button_config = self.create_icon_button("Configuración", "configuracion.png")
+        self.button_config.clicked.connect(self.ver_configuracion)
+        top_layout.addWidget(self.button_config)
+
+        main_layout.addLayout(top_layout)
+
+        # Etiqueta de bienvenida centrada
+        self.label = QLabel("Hola, soy PROMPTY! \ntu asistente de voz", self)
+        self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.label.setFont(QFont("Roboto", 16))
+        main_layout.addWidget(self.label)
+
+        # Botón de micrófono centrado
+        self.button_microfono = QPushButton("")
+        self.button_microfono.setFixedSize(100, 100)
+        self.button_microfono.setStyleSheet("""
+            QPushButton {
+                border: none;
+                border-radius: 50px;
+                background-color: #c1eaf0;
+            }
+            QPushButton:hover {
+                background-color: #ea8278;
+            }
+        """)
+        directorio_actual = os.path.join(os.path.dirname(os.path.abspath(__file__)), "resources")
+        ruta_icono_mic = os.path.join(directorio_actual, "microphone_icon.png")
+        if os.path.exists(ruta_icono_mic):
+            self.button_microfono.setIcon(QIcon(ruta_icono_mic))
+            self.button_microfono.setIconSize(QSize(50, 50))
+        else:
+            print(f"⚠ Icono no encontrado en: {ruta_icono_mic}")
+        self.button_microfono.clicked.connect(self.activate_voice)
+        main_layout.addWidget(self.button_microfono, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        # Caja de texto para mostrar lo que diga el asistente de voz (solo lectura)
+        self.text_output = QTextEdit()
+        self.text_output.setReadOnly(True)
+        self.text_output.setPlaceholderText("Aquí se mostrará lo que diga el asistente de voz...")
+        self.text_output.setFixedHeight(100)
+        main_layout.addWidget(self.text_output)
+
+        # Botón de salir centrado en la parte inferior
+        self.button_salir = QPushButton("Salir")
+        self.button_salir.setFixedSize(150, 40)
+        self.button_salir.setStyleSheet("background-color: #ff6347; color: white; border-radius: 10px;")
+        self.button_salir.clicked.connect(self.close)
+        main_layout.addWidget(self.button_salir, alignment=Qt.AlignmentFlag.AlignCenter)
+
+    def create_icon_button(self, tooltip, icon_file):
+        """Crea un botón con icono y tooltip, sin texto visible. Guarda la ruta original en el botón."""
+        button = QPushButton("")
+        button.setToolTip(tooltip)
+        button.setFixedSize(40, 40)
+        button.setStyleSheet("border: none; background-color: transparent;")
+        directorio_actual = os.path.join(os.path.dirname(os.path.abspath(__file__)), "resources")
+        ruta_icono = os.path.join(directorio_actual, icon_file)
+        if os.path.exists(ruta_icono):
+            button.setIcon(QIcon(ruta_icono))
+            button.setIconSize(QSize(30, 30))
+            # Guardamos la ruta original para poder actualizar el icono según el modo
+            button.icon_file = ruta_icono
+        else:
+            print(f"⚠ Icono no encontrado: {ruta_icono}")
+        return button
+
+    def ver_usuario(self):
+        """Abre la ventana de usuario."""
+        if self.ventana_usuario is None:
+            self.ventana_usuario = UsuarioWindow()
+        self.ventana_usuario.show()
+
+    def ver_ayuda(self):
+        """Abre la ventana de ayuda."""
+        if self.ventana_ayuda is None:
+            self.ventana_ayuda = AyudaWindow()
+        self.ventana_ayuda.show()
+
+    def ver_configuracion(self):
+        """Abre la ventana de configuración."""
+        if self.ventana_configuracion is None:
+            self.ventana_configuracion = ConfiguracionWindow()
+        self.ventana_configuracion.show()
+
+    def activate_voice(self):
+        """Simula la activación de reconocimiento de voz y muestra un mensaje en la caja de texto."""
+        self.label.setText("Escuchando...")
+        self.text_output.setText("El asistente de voz ha comenzado a escuchar.")
+        print("Se activó el reconocimiento de voz.")
+
+    def activar_modo_oscuro(self):
+        """Alterna entre modo oscuro y modo claro y actualiza el color de los iconos."""
+        if not self.dark_mode_enabled:
+            # Modo oscuro: aplicar stylesheet oscuro, actualizar iconos a blanco
+            self.setStyleSheet("background-color: #222; color: white;")
+            self.label.setText("Modo oscuro activado.")
+            self.dark_mode_enabled = True
+
+            # Actualizar iconos a blanco usando get_colored_icon
+            self.button_usuario.setIcon(get_colored_icon(self.button_usuario.icon_file, QColor("white")))
+            self.button_ayuda.setIcon(get_colored_icon(self.button_ayuda.icon_file, QColor("white")))
+            self.button_modo_oscuro.setIcon(get_colored_icon(self.button_modo_oscuro.icon_file, QColor("white")))
+            self.button_config.setIcon(get_colored_icon(self.button_config.icon_file, QColor("white")))
+        else:
+            # Modo claro: eliminar stylesheet personalizado y restaurar iconos originales
+            self.setStyleSheet("")
+            self.label.setText("Modo claro activado.")
+            self.dark_mode_enabled = False
+
+            # Restaurar iconos originales
+            self.button_usuario.setIcon(QIcon(self.button_usuario.icon_file))
+            self.button_ayuda.setIcon(QIcon(self.button_ayuda.icon_file))
+            self.button_modo_oscuro.setIcon(QIcon(self.button_modo_oscuro.icon_file))
+            self.button_config.setIcon(QIcon(self.button_config.icon_file))
+
+class LoginWindow(QWidget):
+    """Pantalla de inicio de sesión simple."""
+
+    def __init__(self, gestor_roles=None):
+        super().__init__()
+        self.setWindowTitle("Iniciar sesión")
+        self.gestor_roles = gestor_roles or GestorRoles()
+        self.setup_ui()
+
+    def setup_ui(self):
+        layout = QVBoxLayout()
+        self.cif_input = QLineEdit()
+        self.cif_input.setPlaceholderText("CIF")
+        self.pass_input = QLineEdit()
+        self.pass_input.setPlaceholderText("Contraseña")
+        self.pass_input.setEchoMode(QLineEdit.EchoMode.Password)
+        self.login_button = QPushButton("Iniciar sesión")
+        self.login_button.clicked.connect(self.verificar)
+        self.forgot_button = QPushButton("Olvidé mi contraseña")
+        self.forgot_button.clicked.connect(self.restablecer)
+        layout.addWidget(QLabel("🔐 Iniciar sesión en PROMPTY"))
+        layout.addWidget(self.cif_input)
+        layout.addWidget(self.pass_input)
+        layout.addWidget(self.login_button)
+        layout.addWidget(self.forgot_button)
+        self.setLayout(layout)
+
+    def verificar(self):
+        usuario = self.gestor_roles.autenticar(
+            self.cif_input.text().strip(), self.pass_input.text().strip()
+        )
+        if usuario:
+            self.hide()
+            self.main = PROMPTYWindow()
+            self.main.show()
+        else:
+            QMessageBox.warning(self, "Error", "CIF o contraseña incorrectos")
+
+    def restablecer(self):
+        cif = self.cif_input.text().strip()
+        if not cif:
+            QMessageBox.information(self, "Info", "Ingresa tu CIF para continuar")
+            return
+        nueva = self.gestor_roles.restablecer_contrasena(cif)
+        if nueva:
+            QMessageBox.information(
+                self,
+                "Contraseña temporal",
+                f"Tu nueva contraseña temporal es: {nueva}",
+            )
+        else:
+            QMessageBox.warning(self, "Error", "CIF no encontrado")
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    login = LoginWindow()
+    login.show()
+    sys.exit(app.exec())

--- a/PROMPTY_2.5/views/login.py
+++ b/PROMPTY_2.5/views/login.py
@@ -10,22 +10,50 @@ class VistaLogin:
     def __init__(self, gestor_roles=None):
         self.gestor_roles = gestor_roles or GestorRoles()
 
+    def verificar_credenciales(self, cif, clave):
+        """Devuelve el usuario si las credenciales son válidas, None en caso contrario."""
+        return self.gestor_roles.autenticar(cif, clave)
+
     def iniciar(self):
         while True:
             limpiar_pantalla()
             print(f"{Fore.CYAN}🔐 Iniciar sesión en PROMPTY{Style.RESET_ALL}")
-            cif = input(f"{Fore.YELLOW}CIF:{Style.RESET_ALL} ").strip()
-            clave = input(f"{Fore.YELLOW}Contraseña:{Style.RESET_ALL} ").strip()
+            print("1. Iniciar sesión")
+            print("2. Olvidé mi contraseña")
+            print("3. Salir")
+            opcion = input("Selecciona una opción: ").strip()
 
-            usuario = self.gestor_roles.autenticar(cif, clave)
+            if opcion == "1":
+                cif = input(f"{Fore.YELLOW}CIF:{Style.RESET_ALL} ").strip()
+                clave = input(f"{Fore.YELLOW}Contraseña:{Style.RESET_ALL} ").strip()
+                usuario = self.verificar_credenciales(cif, clave)
 
-            if usuario:
-                vista = VistaTerminal(usuario)
-                resultado = vista.iniciar()
-                if resultado == "logout":
-                    limpiar_pantalla()
-                    continue
+                if usuario:
+                    vista = VistaTerminal(usuario)
+                    resultado = vista.iniciar()
+                    if resultado == "logout":
+                        limpiar_pantalla()
+                        continue
+                    break
+                else:
+                    print(f"{Fore.RED}❌ CIF o contraseña incorrectos.{Style.RESET_ALL}")
+                    input("Presiona Enter para continuar...")
+            elif opcion == "2":
+                self.restablecer_contrasena()
+            elif opcion == "3":
                 break
             else:
-                print(f"{Fore.RED}❌ CIF o contraseña incorrectos.{Style.RESET_ALL}")
+                print("Opción no válida")
+                input("Presiona Enter para continuar...")
+
+    def restablecer_contrasena(self):
+        limpiar_pantalla()
+        print("🔑 Recuperar contraseña")
+        cif = input("CIF: ").strip()
+        nueva = self.gestor_roles.restablecer_contrasena(cif)
+        if nueva:
+            print(f"Tu nueva contraseña temporal es: {nueva}")
+        else:
+            print("❌ CIF no encontrado.")
+        input("Presiona Enter para continuar...")
 

--- a/PROMPTY_2.5/views/terminal.py
+++ b/PROMPTY_2.5/views/terminal.py
@@ -128,21 +128,21 @@ class VistaTerminal:
         return "exit"
 
     def mostrar_bienvenida(self):
-        print(f"""{Fore.CYAN}
-¡Hola! Soy PROMPTY 2.5, tu asistente virtual de escritorio.
-{Fore.YELLOW}Estoy listo para ayudarte con tareas básicas usando tu voz o el teclado.
-
-{Fore.GREEN}Puedes pedirme que:{Style.RESET_ALL}
-1. Te diga la fecha y hora actual.
-2. Abra un archivo o carpeta (puedes escribir la ruta o buscarla).
-3. Busque algo en YouTube o en tu navegador preferido (puedes usar un término o ingresar una URL).
-4. Te comparta un dato curioso.
-5. Te hable sobre el programa y sus creadores.
-6. Acceder al modo administrador (con contraseña).
-7. Modificar tus datos de usuario.
-8. Cerrar sesión para iniciar con otro usuario.
-9. Salir del programa.
-""")
+        print(f"{Fore.CYAN}¡Hola! Soy PROMPTY 2.5, tu asistente virtual de escritorio.{Style.RESET_ALL}")
+        print(f"{Fore.YELLOW}Estoy listo para ayudarte con tareas básicas usando tu voz o el teclado.{Style.RESET_ALL}\n")
+        print(f"{Fore.GREEN}Puedes pedirme que:{Style.RESET_ALL}")
+        print("1. Te diga la fecha y hora actual.")
+        print("2. Abra un archivo o carpeta (puedes escribir la ruta o buscarla).")
+        print("3. Busque algo en YouTube o en tu navegador preferido (puedes usar un término o ingresar una URL).")
+        print("4. Te comparta un dato curioso.")
+        print("5. Te hable sobre el programa y sus creadores.")
+        if self.usuario.es_admin():
+            print("6. Acceder al modo administrador.")
+        else:
+            print("6. Acceder a funciones admin (requerirá credenciales de un administrador).")
+        print("7. Modificar tus datos de usuario.")
+        print("8. Cerrar sesión para iniciar con otro usuario.")
+        print("9. Salir del programa.")
 
     def menu_configuracion_voz(self):
         while True:
@@ -177,12 +177,14 @@ class VistaTerminal:
 
     def menu_admin(self):
         print("\n🔐 MODO ADMINISTRADOR")
-        cif = input("CIF del administrador: ").strip()
-        clave = input("Contraseña: ").strip()
-        admin = self.gestor_roles.autenticar(cif, clave)
-        if not admin or not admin.es_admin():
-            print("❌ Credenciales incorrectas.")
-            return
+        admin = self.usuario
+        if not self.usuario.es_admin():
+            cif = input("CIF del administrador: ").strip()
+            clave = input("Contraseña: ").strip()
+            admin = self.gestor_roles.autenticar(cif, clave)
+            if not admin or not admin.es_admin():
+                print("❌ Credenciales incorrectas.")
+                return
         print("🔓 Acceso concedido.")
         while True:
             print("\n⚙️ OPCIONES DE ADMINISTRADOR")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cada versión cuenta con su propio archivo principal:
 
 - **Prompty1.0**: scripts iniciales ubicados en `Prompty1.0`. Ejecuta por ejemplo `python Prompty1.0.py` o `Prompty1.2.py` según el script que quieras probar.
 - **PROMPTY_2.0**: versión modularizada. Corre `python PROMPTY_2.0/main.py`.
-- **PROMPTY_2.5**: prototipo con estructura de modelos y servicios. Corre `python PROMPTY_2.5/main.py`.
+- **PROMPTY_2.5**: prototipo con estructura de modelos y servicios. Al correr `python PROMPTY_2.5/main.py` podrás elegir entre la terminal o una interfaz gráfica.
 
 Asegúrate de usar Python 3.13
 


### PR DESCRIPTION
## Summary
- add basic PyQt GUI moved under `views/` and include a login window
- show different terminal options depending on the user role
- allow password recovery via `restablecer_contrasena`
- document new GUI support
- skip admin credential prompt when already logged in
- expose `verificar_credenciales` for shared login logic
- remove binary icon assets causing PR failures
- ask whether to launch GUI or terminal on startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f5f516c748332b43e8bf9259a7c04