### PR TITLE
Add tests for role manager and basic commands

### DIFF
--- a/tests/test_comandos_basicos.py
+++ b/tests/test_comandos_basicos.py
@@ -1,0 +1,41 @@
+import datetime
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'PROMPTY_2.5'))
+
+from services import comandos_basicos
+
+
+class FixedDateTime(datetime.datetime):
+    fixed = datetime.datetime(2020, 1, 2, 15, 30, 45)
+
+    @classmethod
+    def now(cls):
+        return cls.fixed
+
+
+def test_mostrar_fechas(monkeypatch):
+    monkeypatch.setattr(comandos_basicos.datetime, "datetime", FixedDateTime)
+    cb = comandos_basicos.ComandosBasicos()
+    assert cb.mostrar_fecha() == "📅 La fecha de hoy es 02/01/2020."
+    assert cb.mostrar_hora() == "🕒 La hora actual es 03:30 PM."
+    assert cb.mostrar_fecha_hora() == "📆 02/01/2020 🕒 15:30:45"
+
+
+def test_construir_url():
+    cb = comandos_basicos.ComandosBasicos()
+    assert cb.construir_url("hola mundo", "youtube") == "https://www.youtube.com/results?search_query=hola+mundo"
+    assert cb.construir_url("hola mundo", "navegador") == "https://www.google.com/search?q=hola+mundo"
+    assert cb.construir_url("hola", "otro") is None
+
+
+def test_abrir_url(monkeypatch):
+    opened = {}
+    monkeypatch.setattr(comandos_basicos.shutil, "which", lambda _: None)
+    monkeypatch.setattr(comandos_basicos.webbrowser, "open", lambda url: opened.setdefault("url", url))
+
+    cb = comandos_basicos.ComandosBasicos()
+    assert cb.abrir_url("ftp://example.com").startswith("\u274c")
+    assert cb.abrir_url("https://example.com") == "🌐 Abriendo: https://example.com"
+    assert opened["url"] == "https://example.com"

--- a/tests/test_gestor_roles.py
+++ b/tests/test_gestor_roles.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'PROMPTY_2.5'))
+
+from services.gestor_roles import GestorRoles
+from utils import helpers
+
+
+def crear_archivo_usuarios(tmp_path):
+    datos = {
+        "usuarios": [
+            {
+                "cif": "1111",
+                "nombre": "User1",
+                "rol": "admin",
+                "contrasena": helpers.hash_password("pass1"),
+            }
+        ]
+    }
+    ruta = tmp_path / "usuarios.json"
+    ruta.write_text(json.dumps(datos), encoding="utf-8")
+    return ruta
+
+
+def test_autenticar_ok(tmp_path):
+    ruta = crear_archivo_usuarios(tmp_path)
+    gr = GestorRoles(ruta)
+    usuario = gr.autenticar("1111", "pass1")
+    assert usuario is not None
+    assert usuario.nombre == "User1"
+
+
+def test_autenticar_falla(tmp_path):
+    ruta = crear_archivo_usuarios(tmp_path)
+    gr = GestorRoles(ruta)
+    assert gr.autenticar("1111", "no") is None
+
+
+def test_registrar_usuario(monkeypatch, tmp_path):
+    ruta = crear_archivo_usuarios(tmp_path)
+    gr = GestorRoles(ruta)
+
+    monkeypatch.setattr(helpers, "generar_cif", lambda existentes=None: "2222")
+    monkeypatch.setattr(helpers, "generar_contrasena", lambda longitud=8: "pass2")
+
+    cif, contrasena = gr.registrar_usuario("User2", "usuario")
+    assert cif == "2222"
+    assert contrasena == "pass2"
+    nuevo = gr.obtener_usuario_por_cif("2222")
+    assert nuevo.nombre == "User2"

--- a/tests/test_permisos.py
+++ b/tests/test_permisos.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'PROMPTY_2.5'))
+
+from services.permisos import Permisos
+
+
+def test_permisos_basicos():
+    p = Permisos()
+    assert p.tiene_permiso('admin', 'editar_voz')
+    assert not p.tiene_permiso('usuario', 'editar_voz')
+    assert 'agregar_comando' in p.listar_permisos('admin')


### PR DESCRIPTION
## Summary
- add unit tests for `GestorRoles` to cover authentication and registration
- cover permission checks in `Permisos`
- test date/time and URL helpers in `ComandosBasicos`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6eaa0a848332be9b6e35d15e7ddb