### PR TITLE
Corrige ayuda y comando admin

### DIFF
--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -194,8 +194,9 @@ class AyudaWindow(QWidget):
         self.setGeometry(250, 250, 400, 350)
         layout = QVBoxLayout()
 
-        ayuda = QTextEdit(self._generar_texto(usuario))
+        ayuda = QTextEdit()
         ayuda.setReadOnly(True)
+        ayuda.setHtml(self._generar_texto(usuario))
         layout.addWidget(ayuda)
 
         boton_cerrar = QPushButton("Cerrar")
@@ -205,33 +206,59 @@ class AyudaWindow(QWidget):
         self.setLayout(layout)
 
     def _generar_texto(self, usuario):
-        lineas = [
-            "¡Hola! Soy PROMPTY 3.0, tu asistente virtual de escritorio.",
-            "Estoy listo para ayudarte con tareas básicas usando tu voz o el teclado.",
-            "",
-            "Puedes pedirme que:",
-            "1. Te diga la fecha y hora actual.",
-            "2. Abra un archivo o carpeta (puedes escribir la ruta o buscarla).",
-            "3. Busque algo en YouTube o en tu navegador preferido (puedes usar un término o ingresar una URL).",
-            "4. Te comparta un dato curioso.",
-            "5. Te hable sobre el programa y sus creadores.",
+        items = [
+            "Te diga la fecha y hora actual.",
+            "Abra un archivo o carpeta (puedes escribir la ruta o buscarla).",
+            "Busque algo en YouTube o en tu navegador preferido (puedes usar un término o ingresar una URL).",
+            "Te comparta un dato curioso.",
+            "Te hable sobre el programa y sus creadores.",
         ]
         if usuario.es_admin():
-            lineas.append("6. Acceder al modo administrador.")
+            items.append("Funciones admin.")
         else:
-            lineas.append(
-                "6. Acceder a funciones admin (requerirá credenciales de un administrador)."
-            )
-        lineas.extend(
-            [
-                "7. Cerrar sesión para iniciar con otro usuario.",
-                "8. Salir del programa.",
-            ]
+            items.append("Acceder al modo admin (requerirá credenciales de un administrador).")
+        items.append("Modificar tus datos de usuario.")
+        items.append("Cerrar sesión para iniciar con otro usuario.")
+        items.append("Salir del programa.")
+
+        lista = "".join(f"<li>{it}</li>" for it in items)
+        return (
+            "<h3>¡Hola! Soy PROMPTY 3.0, tu asistente virtual de escritorio.</h3>"
+            "<p>Estoy listo para ayudarte con tareas básicas usando tu voz o el teclado.</p>"
+            "<p>Puedes pedirme que:</p>"
+            f"<ol>{lista}</ol>"
+            "<p>Si PROMPTY no reconoce un comando, verás un mensaje recordándote que puedes abrir esta ayuda.</p>"
         )
-        lineas.append(
-            "\nSi PROMPTY no reconoce un comando, verás un mensaje recordándote que puedes abrir esta ayuda."
-        )
-        return "\n".join(lineas)
+
+
+class AdminWindow(QWidget):
+    """Opciones básicas de administración."""
+
+    def __init__(self, parent, servicio_voz, gestor_roles):
+        super().__init__(parent)
+        self.parent = parent
+        self.servicio_voz = servicio_voz
+        self.gestor_roles = gestor_roles
+        self.setWindowTitle("Funciones admin")
+        self.setGeometry(200, 200, 260, 150)
+        layout = QVBoxLayout()
+
+        btn_voz = QPushButton("Configurar voz")
+        btn_voz.clicked.connect(parent.ver_configuracion)
+        layout.addWidget(btn_voz)
+
+        btn_users = QPushButton("Gestionar usuarios")
+        btn_users.clicked.connect(self.no_implementado)
+        layout.addWidget(btn_users)
+
+        btn_cerrar = QPushButton("Cerrar")
+        btn_cerrar.clicked.connect(self.close)
+        layout.addWidget(btn_cerrar)
+
+        self.setLayout(layout)
+
+    def no_implementado(self):
+        QMessageBox.information(self, "Admin", "Función no implementada en la interfaz")
         
 class PROMPTYWindow(QMainWindow):
     def __init__(self, usuario, logout_callback=None):
@@ -247,6 +274,7 @@ class PROMPTYWindow(QMainWindow):
         self.ventana_usuario = None
         self.ventana_editor_usuario = None
         self.ventana_ayuda = None
+        self.ventana_admin = None
         self.dark_mode_enabled = False
         self.setup_ui()
 
@@ -369,6 +397,24 @@ class PROMPTYWindow(QMainWindow):
             self.ventana_configuracion = ConfiguracionWindow(self.servicio_voz)
         self.ventana_configuracion.show()
 
+    def ver_admin(self):
+        if not self.usuario.es_admin():
+            cif, ok = QInputDialog.getText(self, "Modo admin", "CIF del administrador:")
+            if not ok:
+                return
+            clave, ok2 = QInputDialog.getText(
+                self, "Modo admin", "Contraseña:", QLineEdit.EchoMode.Password
+            )
+            if not ok2:
+                return
+            admin = self.gestor_roles.autenticar(cif.strip(), clave.strip())
+            if not admin or not admin.es_admin():
+                QMessageBox.warning(self, "Error", "Credenciales incorrectas")
+                return
+        if self.ventana_admin is None:
+            self.ventana_admin = AdminWindow(self, self.servicio_voz, self.gestor_roles)
+        self.ventana_admin.show()
+
     def activate_voice(self):
         mensaje_original = self.label.text()
         self.label.setText("\ud83c\udf99\ufe0f Escuchando...")
@@ -395,6 +441,9 @@ class PROMPTYWindow(QMainWindow):
         if comando == "editar_usuario":
             self.mostrar_editor_usuario()
             respuesta = "Abriendo editor de usuario..."
+        elif comando == "modo_admin":
+            self.ver_admin()
+            respuesta = "Abriendo funciones de administrador..."
         else:
             interactivos = {"abrir_carpeta", "abrir_con_opcion", "buscar_en_navegador", "buscar_en_youtube"}
             if comando in interactivos:

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -140,9 +140,9 @@ class VistaTerminal:
         print("4. Te comparta un dato curioso.")
         print("5. Te hable sobre el programa y sus creadores.")
         if self.usuario.es_admin():
-            print("6. Acceder al modo administrador.")
+            print("6. Funciones admin.")
         else:
-            print("6. Acceder a funciones admin (requerirá credenciales de un administrador).")
+            print("6. Acceder al modo admin (requerirá credenciales de un administrador).")
         print("7. Modificar tus datos de usuario.")
         print("8. Cerrar sesión para iniciar con otro usuario.")
         print("9. Salir del programa.")


### PR DESCRIPTION
## Summary
- refine help text wording for admin functions
- add AdminWindow and hook up 'modo_admin' command in the GUI
- tweak terminal welcome message to match help

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f87426ea883328cf2eb10db41170b