### PR TITLE
Fix GUI login and info prompt

### DIFF
--- a/PROMPTY_3.0/main.py
+++ b/PROMPTY_3.0/main.py
@@ -14,6 +14,9 @@ def main():
         app = QApplication(sys.argv)
         login = LoginWindow()
         login.show()
+        # Aseguramos que la ventana aparezca en primer plano
+        login.raise_()
+        login.activateWindow()
         app.exec()
     else:
         VistaLogin().iniciar()

--- a/PROMPTY_3.0/services/comandos_basicos.py
+++ b/PROMPTY_3.0/services/comandos_basicos.py
@@ -137,7 +137,7 @@ class ComandosBasicos:
             return f"🤔 Dato curioso: {choice(datos)}"
         return resultado
 
-    def info_sistema(self, ruta=None):
+    def info_sistema(self, ruta=None, entrada_manual_func=None):
         if ruta is None:
             ruta = os.path.join(os.path.dirname(__file__), '..', 'data', 'info_programa.txt')
         ruta = os.path.abspath(ruta)
@@ -150,16 +150,23 @@ class ComandosBasicos:
         }
 
         while True:
-            print("\n¿Sobre qué deseas saber?")
-            print("1. Sobre los creadores")
-            print("2. Sobre el programa")
-            print("3. Sobre el desarrollo")
-            print("4. Sobre la licencia de uso")
-            opcion = input("Selecciona una opción (1-4): ").strip()
+            mensaje = (
+                "\n¿Sobre qué deseas saber?\n"
+                "1. Sobre los creadores\n"
+                "2. Sobre el programa\n"
+                "3. Sobre el desarrollo\n"
+                "4. Sobre la licencia de uso"
+            )
+            if entrada_manual_func:
+                opcion = entrada_manual_func(f"{mensaje}\nSelecciona una opción (1-4): ").strip()
+            else:
+                print(mensaje)
+                opcion = input("Selecciona una opción (1-4): ").strip()
             titulo = secciones.get(opcion)
             if titulo:
                 break
-            print("❌ Opción inválida.")
+            if not entrada_manual_func:
+                print("❌ Opción inválida.")
 
         try:
             with open(ruta, "r", encoding="utf-8") as archivo:

--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -18,7 +18,7 @@ class GestorComandos:
             "buscar_en_navegador": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=e),
             "buscar_general": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=e),
             "dato_curioso": lambda a, e: self.basicos.mostrar_dato_curioso(),
-            "info_programa": lambda a, e: self.basicos.info_sistema(),
+            "info_programa": lambda a, e: self.basicos.info_sistema(entrada_manual_func=e),
         }
 
     def establecer_usuario(self, usuario):

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -459,7 +459,7 @@ class PROMPTYWindow(QMainWindow):
             self.close()
             return
         else:
-            interactivos = {"abrir_carpeta", "abrir_con_opcion", "buscar_en_navegador", "buscar_en_youtube"}
+            interactivos = {"abrir_carpeta", "abrir_con_opcion", "buscar_en_navegador", "buscar_en_youtube", "info_programa"}
             if comando in interactivos:
                 respuesta = self.gestor_comandos.ejecutar_comando(comando, argumentos, self.preguntar)
             else:


### PR DESCRIPTION
## Summary
- ensure GUI login window raises to front on start
- support asking section choice from GUI for info_programa
- treat info_programa as interactive in GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f98c37c648332bc22ac9cc77c5804