### PR TITLE
Mensajes de audio en la interfaz

### DIFF
--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -33,12 +33,16 @@ class ServicioVoz:
         self.engine.runAndWait()
         return texto_limpio
 
-    def escuchar(self):
+    def escuchar(self, notify=None):
         """Escucha desde el micrófono y devuelve el texto reconocido.
-        Devuelve ``None`` si no se entiende o ``"__error_red"`` si ocurre un
-        problema de conexión."""
+        Si se proporciona ``notify`` se llamará con el mensaje de escucha en
+        lugar de imprimirlo en la terminal. Devuelve ``None`` si no se entiende
+        o ``"__error_red"`` si ocurre un problema de conexión."""
         with sr.Microphone() as source:
-            print("🎙️ Escuchando...")
+            if notify:
+                notify("🎙️ Escuchando...")
+            else:
+                print("🎙️ Escuchando...")
             audio = self.recognizer.listen(source)
         try:
             texto = self.recognizer.recognize_google(audio, language="es-ES")

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -420,14 +420,13 @@ class PROMPTYWindow(QMainWindow):
     def activate_voice(self):
         mensaje_original = self.label.text()
         self.label.setText("\ud83c\udf99\ufe0f Escuchando...")
-        self.text_output.append("\ud83c\udf99\ufe0f Escuchando...")
-        texto = self.servicio_voz.escuchar()
+        texto = self.servicio_voz.escuchar(notify=self.text_output.append)
         self.label.setText(mensaje_original)
         if not texto:
             self.text_output.append("\u274c No se entendió el comando")
             self.servicio_voz.hablar("No se entendió el comando")
             return
-        self.text_output.append(f"\ud83d\udde3\ufe0f {texto}")
+        self.text_output.append(f"\ud83d\udde3\ufe0f Entendí: {texto}")
         self.ejecutar_comando_desde_texto(texto)
 
     def process_command(self):


### PR DESCRIPTION
## Summary
- show "escuchando" message through a callback in `ServicioVoz`
- display the recognized text prefixed with "Entendí" in the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9bb5a4508332a0344af77bc6f8ed