### PR TITLE
Mensajes de audio en la interfaz

### DIFF
--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -33,12 +33,16 @@ class ServicioVoz:
         self.engine.runAndWait()
         return texto_limpio
 
-    def escuchar(self):
+    def escuchar(self, notify=None):
         """Escucha desde el micrófono y devuelve el texto reconocido.
-        Devuelve ``None`` si no se entiende o ``"__error_red"`` si ocurre un
-        problema de conexión."""
+        Si se proporciona ``notify`` se llamará con el mensaje de escucha en
+        lugar de imprimirlo en la terminal. Devuelve ``None`` si no se entiende
+        o ``"__error_red"`` si ocurre un problema de conexión."""
         with sr.Microphone() as source:
-            print("🎙️ Escuchando...")
+            if notify:
+                notify("🎙️ Escuchando...")
+            else:
+                print("🎙️ Escuchando...")
             audio = self.recognizer.listen(source)
         try:
             texto = self.recognizer.recognize_google(audio, language="es-ES")

--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -16,7 +16,7 @@ class GestorComandos:
             "abrir_con_opcion": lambda a, e: self.basicos.abrir_con_opcion(entrada_manual_func=e),
             "buscar_en_youtube": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(destino_predefinido="youtube", entrada_manual_func=e if not a else None),
             "buscar_en_navegador": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=e),
-            "buscar_general": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=e),
+            "buscar_general": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(destino_predefinido="navegador", entrada_manual_func=e),
             "dato_curioso": lambda a, e: self.basicos.mostrar_dato_curioso(),
             "info_programa": lambda a, e: self.basicos.info_sistema(entrada_manual_func=e),
         }

--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -10,6 +10,13 @@ def interpretar(texto):
 
     texto = texto.lower().strip()
 
+    if "buscar" in texto:
+        if "youtube" in texto:
+            return "buscar_en_youtube", None
+        if "google" in texto or "navegador" in texto:
+            return "buscar_general", None
+        return "buscar_en_navegador", None
+
     numero_comandos = {
         ("1", "uno"): "fecha_hora",
         ("2", "dos"): "abrir_con_opcion",

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -420,14 +420,18 @@ class PROMPTYWindow(QMainWindow):
     def activate_voice(self):
         mensaje_original = self.label.text()
         self.label.setText("\ud83c\udf99\ufe0f Escuchando...")
-        self.text_output.append("\ud83c\udf99\ufe0f Escuchando...")
-        texto = self.servicio_voz.escuchar()
+
+        def notify_gui(msg):
+            self.text_output.append(msg)
+            QApplication.processEvents()
+
+        texto = self.servicio_voz.escuchar(notify=notify_gui)
         self.label.setText(mensaje_original)
         if not texto:
             self.text_output.append("\u274c No se entendió el comando")
             self.servicio_voz.hablar("No se entendió el comando")
             return
-        self.text_output.append(f"\ud83d\udde3\ufe0f {texto}")
+        self.text_output.append(f"\ud83d\udde3\ufe0f Entendí: {texto}")
         self.ejecutar_comando_desde_texto(texto)
 
     def process_command(self):

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -17,6 +17,11 @@ class TestInterpretador(unittest.TestCase):
         self.assertEqual(interpretar('quiero un dato curioso')[0], 'dato_curioso')
         self.assertEqual(interpretar('cerrar sesion')[0], 'cerrar_sesion')
 
+    def test_busquedas(self):
+        self.assertEqual(interpretar('buscar receta en youtube')[0], 'buscar_en_youtube')
+        self.assertEqual(interpretar('buscar fotos en google')[0], 'buscar_general')
+        self.assertEqual(interpretar('buscar un archivo')[0], 'buscar_en_navegador')
+
     def test_desconocido(self):
         self.assertEqual(interpretar('xyz')[0], 'comando_no_reconocido')
 


### PR DESCRIPTION
## Summary
- show "escuchando" message through a callback in `ServicioVoz`
- display the recognized text prefixed with "Entendí" in the GUI
- skip the destination prompt when asking to search on Google
- ask for a destination only when the command contains just "buscar"
- test interpreter search logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f9bb5a4508332a0344af77bc6f8ed