### PR TITLE
Fix search command prompt

### DIFF
--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -60,7 +60,13 @@ class VistaTerminal:
                 continue
 
             # Comandos que requieren entrada
-            comandos_interactivos = ["abrir_carpeta", "abrir_con_opcion", "buscar_en_navegador", "buscar_en_youtube"]
+            comandos_interactivos = [
+                "abrir_carpeta",
+                "abrir_con_opcion",
+                "buscar_en_navegador",
+                "buscar_en_youtube",
+                "buscar_general",
+            ]
             if comando in comandos_interactivos:
                 respuesta = self.gestor_comandos.ejecutar_comando(comando, argumentos, entrada_manual_func=input)
             else:


### PR DESCRIPTION
## Summary
- fix terminal interactive commands set to include `buscar_general`
- ensure terminal view prompts for input when search commands omit terms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa7257e788332add95aad0d67b228