### PR TITLE
Fix login window focus in GUI

### DIFF
--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -716,8 +716,14 @@ class LoginWindow(QWidget):
         self.gestor_roles = gestor_roles or GestorRoles()
         self.setup_ui()
 
+    def show(self):
+        """Muestra la ventana asegurando que quede al frente."""
+        super().show()
+        self.raise_()
+        self.activateWindow()
+
     def showEvent(self, event):
-        """Se asegura de que la ventana se muestre en primer plano."""
+        """Garantiza que la ventana reciba el foco al mostrarse."""
         super().showEvent(event)
         self.raise_()
         self.activateWindow()


### PR DESCRIPTION
## Summary
- ensure the login window gains focus when shown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518b0f09c483329978e47cc62013b2