### PR TITLE
Fix music command and scaling

### DIFF
--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -33,12 +33,13 @@ def interpretar(texto):
         ("1", "uno"): "fecha_hora",
         ("2", "dos"): "abrir_con_opcion",
         ("3", "tres"): "buscar_en_navegador",
-        ("4", "cuatro"): "dato_curioso",
-        ("5", "cinco"): "info_programa",
-        ("6", "seis", "administrador", "modo admin"): "modo_admin",
-        ("7", "siete"): "editar_usuario",
-        ("8", "ocho", "cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
-        ("9", "nueve", "salir", "cerrar"): "salir",
+        ("4", "cuatro"): "reproducir_musica",
+        ("5", "cinco"): "dato_curioso",
+        ("6", "seis"): "info_programa",
+        ("7", "siete", "administrador", "modo admin"): "modo_admin",
+        ("8", "ocho"): "editar_usuario",
+        ("9", "nueve", "cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
+        ("10", "diez", "salir", "cerrar"): "salir",
     }
 
     for claves, comando in numero_comandos.items():

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -126,6 +126,8 @@ class ConfiguracionWindow(QWidget):
             self.aplicar_fuente(
                 self.font_combo.currentText(), self.size_slider.value()
             )
+        # Aplicar la fuente seleccionada a esta ventana para reflejar el cambio
+        self.setFont(QFont(self.font_combo.currentText(), self.size_slider.value()))
         QMessageBox.information(self, "Configuración", "Ajustes guardados")
 
 class EditarUsuarioWindow(QWidget):
@@ -231,6 +233,7 @@ class AyudaWindow(QWidget):
             "Te diga la fecha y hora actual.",
             "Abra un archivo o carpeta (puedes escribir la ruta o buscarla).",
             "Busque algo en YouTube o en tu navegador preferido (puedes usar un término o ingresar una URL).",
+            "Reproduzca música en YouTube Music.",
             "Te comparta un dato curioso.",
             "Te hable sobre el programa y sus creadores.",
         ]
@@ -836,7 +839,7 @@ class LoginWindow(QWidget):
         self.activateWindow()
 
     def apply_scaling(self):
-        factor = max(0.8, min(1.5, self.width() / 300))
+        factor = max(0.8, min(2.0, self.width() / 300))
         fuente = QFont(self.font_family, int(self.base_font_size * factor))
         self.cif_input.setFont(fuente)
         self.pass_input.setFont(fuente)

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -66,6 +66,7 @@ class VistaTerminal:
                 "buscar_en_navegador",
                 "buscar_en_youtube",
                 "buscar_general",
+                "reproducir_musica",
             ]
             if comando in comandos_interactivos:
                 respuesta = self.gestor_comandos.ejecutar_comando(comando, argumentos, entrada_manual_func=input)
@@ -143,15 +144,16 @@ class VistaTerminal:
         print("1. Te diga la fecha y hora actual.")
         print("2. Abra un archivo o carpeta (puedes escribir la ruta o buscarla).")
         print("3. Busque algo en YouTube o en tu navegador preferido (puedes usar un término o ingresar una URL).")
-        print("4. Te comparta un dato curioso.")
-        print("5. Te hable sobre el programa y sus creadores.")
+        print("4. Reproduzca música en YouTube Music.")
+        print("5. Te comparta un dato curioso.")
+        print("6. Te hable sobre el programa y sus creadores.")
         if self.usuario.es_admin():
-            print("6. Funciones admin.")
+            print("7. Funciones admin.")
         else:
-            print("6. Acceder al modo admin (requerirá credenciales de un administrador).")
-        print("7. Modificar tus datos de usuario.")
-        print("8. Cerrar sesión para iniciar con otro usuario.")
-        print("9. Salir del programa.")
+            print("7. Acceder al modo admin (requerirá credenciales de un administrador).")
+        print("8. Modificar tus datos de usuario.")
+        print("9. Cerrar sesión para iniciar con otro usuario.")
+        print("10. Salir del programa.")
 
     def menu_configuracion_voz(self):
         while True:

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -9,8 +9,8 @@ class TestInterpretador(unittest.TestCase):
     def test_numeros(self):
         self.assertEqual(interpretar('1')[0], 'fecha_hora')
         self.assertEqual(interpretar('dos')[0], 'abrir_con_opcion')
-        self.assertEqual(interpretar('9')[0], 'salir')
-        self.assertEqual(interpretar('seis')[0], 'modo_admin')
+        self.assertEqual(interpretar('10')[0], 'salir')
+        self.assertEqual(interpretar('siete')[0], 'modo_admin')
 
     def test_palabras_clave(self):
         self.assertEqual(interpretar('abre una carpeta')[0], 'abrir_con_opcion')


### PR DESCRIPTION
## Summary
- include music command in help texts
- allow larger scaling factor in login window
- apply selected font to configuration window
- add interactive prompt for music command
- renumber commands to include music and update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a222428048332af9bb583b3377127