### PR TITLE
Load defaults from config

### DIFF
--- a/PROMPTY_3.0/data/config.py
+++ b/PROMPTY_3.0/data/config.py
@@ -6,6 +6,10 @@ VELOCIDAD_POR_DEFECTO = 150
 # Volumen (0.0 a 1.0)
 VOLUMEN_POR_DEFECTO = 0.9
 
+# Fuente y tamaño de letra predeterminados para la interfaz
+FUENTE_POR_DEFECTO = "Roboto"
+TAMANO_LETRA_POR_DEFECTO = 16
+
 # Configuración predeterminada de la ventana de ayuda
 AYUDA_POS_X = 250
 AYUDA_POS_Y = 250

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -68,7 +68,13 @@ def get_colored_icon(icon_path, color):
 class ConfiguracionWindow(QWidget):
     """Permite ajustar la voz y la fuente de PROMPTY."""
 
-    def __init__(self, servicio_voz, fuente="Roboto", tamano=16, aplicar_fuente=None):
+    def __init__(
+        self,
+        servicio_voz,
+        fuente=config.FUENTE_POR_DEFECTO,
+        tamano=config.TAMANO_LETRA_POR_DEFECTO,
+        aplicar_fuente=None,
+    ):
         super().__init__()
         self.servicio_voz = servicio_voz
         self.aplicar_fuente = aplicar_fuente
@@ -528,8 +534,8 @@ class PROMPTYWindow(QMainWindow):
         self.gestor_comandos = GestorComandos(usuario)
         self.setWindowTitle("PROMPTY - Asistente de Voz")
         self.setGeometry(100, 100, 400, 600)
-        self.font_family = "Roboto"
-        self.base_font_size = 16
+        self.font_family = config.FUENTE_POR_DEFECTO
+        self.base_font_size = config.TAMANO_LETRA_POR_DEFECTO
         self.saludo = "Hola, soy PROMPTY! \ntu asistente de voz"
         self.mensaje_timer = QTimer(self)
         self.ventana_configuracion = None
@@ -831,8 +837,8 @@ class LoginWindow(QWidget):
         self.setWindowTitle("Iniciar sesión")
         self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
         self.gestor_roles = gestor_roles or GestorRoles()
-        self.font_family = "Roboto"
-        self.base_font_size = 14
+        self.font_family = config.FUENTE_POR_DEFECTO
+        self.base_font_size = config.TAMANO_LETRA_POR_DEFECTO
         self.setup_ui()
         self.apply_scaling()
 


### PR DESCRIPTION
## Summary
- centralize interface defaults (voice, font) in `config.py`
- use those defaults in GUI windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2c2f72348332bf47b39bfa772518