### PR TITLE
Improve tree command synonyms

### DIFF
--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -66,6 +66,7 @@ def interpretar(texto):
         ("programa", "creador", "información"): "info_programa",
         ("usuario", "perfil"): "editar_usuario",
         ("ayuda", "opciones", "menu"): "ayuda",
+        ("tree", "árbol", "arbol", "estructura"): "ver_arbol",
         ("salir", "cerrar"): "salir",
         ("cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
     }

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -775,6 +775,9 @@ class PROMPTYWindow(QMainWindow):
             self.mostrar_respuesta(respuesta)
             self.close()
             return
+        elif comando == "ver_arbol":
+            self.ver_arbol_programa()
+            respuesta = "Mostrando estructura del proyecto..."
         else:
             interactivos = {
                 "abrir_carpeta",

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -48,6 +48,9 @@ class VistaTerminal:
             if comando == "ayuda":
                 self.mostrar_bienvenida()
                 continue
+            if comando == "ver_arbol":
+                self.mostrar_arbol()
+                continue
 
             if comando == "comando_no_reconocido":
                 mensaje = (
@@ -154,6 +157,16 @@ class VistaTerminal:
         print("8. Modificar tus datos de usuario.")
         print("9. Cerrar sesión para iniciar con otro usuario.")
         print("10. Salir del programa.")
+
+    def mostrar_arbol(self):
+        """Imprime la estructura de carpetas del proyecto."""
+        root_path = Path(__file__).resolve().parents[2] / "PROMPTY_3.0"
+        for ruta, dirs, files in os.walk(root_path):
+            nivel = len(Path(ruta).relative_to(root_path).parts)
+            indent = "    " * nivel
+            print(f"{indent}{Path(ruta).name}/")
+            for f in files:
+                print(f"{indent}    {f}")
 
     def menu_configuracion_voz(self):
         while True:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Cada versión cuenta con su propio archivo principal:
 
 Asegúrate de usar Python 3.13
 
+Si quieres ver la estructura del proyecto desde la interfaz gráfica, puedes decir palabras como "tree", "árbol" o simplemente "estructura" y se abrirá una ventana con el árbol de carpetas.
+
 ## Estructura de carpetas
 Prompty1.0.py/ # Implementación inicial con varios scripts sueltos
 PROMPTY_2.0/ # Dividido en datos, funciones y utilidades

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -26,6 +26,11 @@ class TestInterpretador(unittest.TestCase):
         self.assertEqual(interpretar('poner cancion')[0], 'reproducir_musica')
         self.assertEqual(interpretar('oir canciones')[0], 'reproducir_musica')
 
+    def test_arbol(self):
+        self.assertEqual(interpretar('tree')[0], 'ver_arbol')
+        self.assertEqual(interpretar('árbol')[0], 'ver_arbol')
+        self.assertEqual(interpretar('estructura del proyecto')[0], 'ver_arbol')
+
     def test_desconocido(self):
         self.assertEqual(interpretar('xyz')[0], 'comando_no_reconocido')
 


### PR DESCRIPTION
## Summary
- expand keyword dictionary to accept `tree`, `árbol`, `arbol` and `estructura`
- handle `ver_arbol` command in GUI and terminal
- document the new voice command
- test new keyword handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a30efe16c83329ed7e62bba152706