### PR TITLE
Improve greeting handling and defaults

### DIFF
--- a/PROMPTY_3.0/services/comandos_basicos.py
+++ b/PROMPTY_3.0/services/comandos_basicos.py
@@ -22,6 +22,14 @@ class ComandosBasicos:
         ahora = datetime.datetime.now()
         return f"📆 {ahora.strftime('%d/%m/%Y')} 🕒 {ahora.strftime('%H:%M:%S')}"
 
+    def responder_saludo(self):
+        saludos = [
+            "¡Hola! ¿En qué puedo ayudarte?",
+            "Hola, ¿qué tal?",
+            "¡Hola! Estoy listo para asistirte."
+        ]
+        return choice(saludos)
+
     def abrir_carpeta(self, ruta):
         try:
             if platform.system() == "Windows":
@@ -47,19 +55,18 @@ class ComandosBasicos:
             root.destroy()
 
     def abrir_con_opcion(self, tipo=None, entrada_manual_func=None):
-        if tipo not in ['archivo', 'carpeta']:
-            if entrada_manual_func:
-                tipo = entrada_manual_func("¿Qué deseas abrir? (carpeta o archivo): ").strip().lower()
-            else:
-                return "❌ Tipo no válido."
+        entrada = entrada_manual_func or input
 
-        if entrada_manual_func:
-            metodo = entrada_manual_func("¿Deseas escribir la ruta (1) o buscarla en el explorador (2)? ").strip()
-        else:
-            return "❌ No se puede continuar sin función de entrada."
+        if tipo not in ['archivo', 'carpeta']:
+            tipo = entrada("¿Qué deseas abrir? (carpeta o archivo): ").strip().lower()
+
+        if tipo not in ['archivo', 'carpeta']:
+            return "❌ Tipo no válido."
+
+        metodo = entrada("¿Deseas escribir la ruta (1) o buscarla en el explorador (2)? ").strip()
 
         if metodo == '1':
-            ruta = entrada_manual_func("Escribe la ruta completa: ").strip()
+            ruta = entrada("Escribe la ruta completa: ").strip()
         elif metodo == '2':
             ruta = self.seleccionar_ruta(tipo)
         else:
@@ -95,21 +102,20 @@ class ComandosBasicos:
 
     def reproducir_musica(self, entrada_manual_func=None):
         """Abre una búsqueda o URL en YouTube Music."""
-        if not entrada_manual_func:
-            return "❌ Sin entrada para música."
+        entrada = entrada_manual_func or input
 
-        opcion = entrada_manual_func(
+        opcion = entrada(
             "¿Deseas buscar un término (1) o ingresar una URL (2)? "
         ).strip()
         if opcion == "1":
-            termino = entrada_manual_func("¿Qué deseas escuchar?: ").strip()
+            termino = entrada("¿Qué deseas escuchar?: ").strip()
             if not termino:
                 return "❌ El término no puede estar vacío."
             url = self.construir_url(termino, "musica")
             mensaje = f"Buscando: {termino}"
 
         elif opcion == "2":
-            url = entrada_manual_func("Introduce la URL completa: ").strip()
+            url = entrada("Introduce la URL completa: ").strip()
             if not url:
                 return "❌ La URL no puede estar vacía."
             mensaje = None
@@ -119,32 +125,28 @@ class ComandosBasicos:
         return self.abrir_url(url, mensaje)
 
     def buscar_en_navegador_con_opcion(self, destino_predefinido=None, entrada_manual_func=None):
+        entrada = entrada_manual_func or input
+
         if not destino_predefinido:
-            if entrada_manual_func:
-                destino = entrada_manual_func(
-                    "¿Dónde deseas buscar? (youtube, navegador o musica): "
-                ).strip().lower()
-            else:
-                return "❌ Sin entrada para destino."
+            destino = entrada(
+                "¿Dónde deseas buscar? (youtube, navegador o musica): "
+            ).strip().lower()
         else:
             destino = destino_predefinido
 
         if destino not in ["youtube", "navegador", "musica"]:
             return "❌ Opción inválida."
 
-        if entrada_manual_func:
-            metodo = entrada_manual_func("¿Deseas buscar un término (1) o ingresar una URL (2)? ").strip()
-        else:
-            return "❌ Sin entrada para método."
+        metodo = entrada("¿Deseas buscar un término (1) o ingresar una URL (2)? ").strip()
 
         if metodo == '1':
-            termino = entrada_manual_func("¿Qué deseas buscar?: ").strip()
+            termino = entrada("¿Qué deseas buscar?: ").strip()
             if not termino:
                 return "❌ El término no puede estar vacío."
             url = self.construir_url(termino, destino)
             mensaje = f"Buscando: {termino}"
         elif metodo == '2':
-            url = entrada_manual_func("Introduce la URL completa: ").strip()
+            url = entrada("Introduce la URL completa: ").strip()
             if not url:
                 return "❌ La URL no puede estar vacía."
             mensaje = None
@@ -174,6 +176,8 @@ class ComandosBasicos:
             ruta = os.path.join(os.path.dirname(__file__), '..', 'data', 'info_programa.txt')
         ruta = os.path.abspath(ruta)
 
+        entrada = entrada_manual_func or input
+
         secciones = {
             "1": "SOBRE LOS CREADORES DE PROMPTY",
             "2": "SOBRE EL PROGRAMA",
@@ -193,7 +197,7 @@ class ComandosBasicos:
                 opcion = entrada_manual_func(f"{mensaje}\nSelecciona una opción (1-4): ").strip()
             else:
                 print(mensaje)
-                opcion = input("Selecciona una opción (1-4): ").strip()
+                opcion = entrada("Selecciona una opción (1-4): ").strip()
             titulo = secciones.get(opcion)
             if titulo:
                 break

--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -20,6 +20,7 @@ class GestorComandos:
             "reproducir_musica": lambda a, e: self.basicos.reproducir_musica(entrada_manual_func=e),
             "dato_curioso": lambda a, e: self.basicos.mostrar_dato_curioso(),
             "info_programa": lambda a, e: self.basicos.info_sistema(entrada_manual_func=e),
+            "saludo": lambda a, e: self.basicos.responder_saludo(),
         }
 
     def establecer_usuario(self, usuario):

--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -1,3 +1,5 @@
+import re
+
 def interpretar(texto):
     """Devuelve (comando, argumentos) a partir de una cadena.
 
@@ -6,6 +8,19 @@ def interpretar(texto):
     """
     texto = texto.lower().strip()
     texto = texto.replace("en el", "en")  # Normaliza "buscar en el navegador" → "buscar en navegador"
+
+    texto_simple = re.sub(r"[!.,?]", "", texto).strip()
+    saludos = [
+        "hola",
+        "hola prompty",
+        "buenos dias",
+        "buenas tardes",
+        "buenas noches",
+        "que tal",
+        "como estas",
+    ]
+    if texto_simple in saludos:
+        return "saludo", None
 
     if "buscar" in texto:
         if "youtube" in texto:
@@ -47,13 +62,13 @@ def interpretar(texto):
             return comando, None
 
     palabras_clave = {
-        ("hora", "fecha"): "fecha_hora",
-        ("carpeta",): "abrir_carpeta",
-        ("archivo",): "abrir_archivo",
-        ("abrir",): "abrir_con_opcion",
+        ("hora", "fecha", "tiempo"): "fecha_hora",
+        ("carpeta", "folder", "directorio"): "abrir_carpeta",
+        ("archivo", "documento", "fichero", "aplicacion", "aplicación", "app"): "abrir_archivo",
+        ("abrir", "abre", "ejecuta"): "abrir_con_opcion",
         ("youtube",): "buscar_en_youtube",
-        ("navegador", "google"): "buscar_en_navegador",
-        ("buscar",): "buscar_general",
+        ("navegador", "google", "internet", "web", "explorador"): "buscar_en_navegador",
+        ("buscar", "investigar", "consultar"): "buscar_general",
         (
             "musica",
             "música",
@@ -61,13 +76,18 @@ def interpretar(texto):
             "cancion",
             "canción",
             "canciones",
+            "escuchar",
+            "reproduce",
+            "pon",
+            "toca",
+            "suena",
         ): "reproducir_musica",
-        ("curioso", "dato"): "dato_curioso",
-        ("programa", "creador", "información"): "info_programa",
-        ("usuario", "perfil"): "editar_usuario",
-        ("ayuda", "opciones", "menu"): "ayuda",
-        ("tree", "árbol", "arbol", "estructura"): "ver_arbol",
-        ("salir", "cerrar"): "salir",
+        ("curioso", "dato", "curiosidad", "sabias"): "dato_curioso",
+        ("programa", "creador", "información", "informacion", "acerca", "sobre"): "info_programa",
+        ("usuario", "perfil", "cuenta"): "editar_usuario",
+        ("ayuda", "opciones", "menu", "ayudar"): "ayuda",
+        ("tree", "árbol", "arbol", "estructura", "directorios", "mapa"): "ver_arbol",
+        ("salir", "cerrar", "adios", "terminar", "exit"): "salir",
         ("cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
     }
 

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -31,6 +31,16 @@ class TestInterpretador(unittest.TestCase):
         self.assertEqual(interpretar('árbol')[0], 'ver_arbol')
         self.assertEqual(interpretar('estructura del proyecto')[0], 'ver_arbol')
 
+    def test_saludos(self):
+        self.assertEqual(interpretar('hola')[0], 'saludo')
+        self.assertEqual(interpretar('hola prompty')[0], 'saludo')
+        self.assertNotEqual(interpretar('hola quiero buscar un video')[0], 'saludo')
+
+    def test_sinonimos(self):
+        self.assertEqual(interpretar('abre el folder')[0], 'abrir_carpeta')
+        self.assertEqual(interpretar('abre un documento')[0], 'abrir_archivo')
+        self.assertEqual(interpretar('exit')[0], 'salir')
+
     def test_desconocido(self):
         self.assertEqual(interpretar('xyz')[0], 'comando_no_reconocido')
 


### PR DESCRIPTION
## Summary
- add `responder_saludo` and hook it in command handler
- allow interactive commands to use standard input by default
- detect simple greetings and expand keyword dictionary
- test new synonyms and greetings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3307760083329ba3e4c5a3b4dc21