### PR TITLE
Fix scaling for exit button

### DIFF
--- a/PROMPTY_3.0/utils/scaling.py
+++ b/PROMPTY_3.0/utils/scaling.py
@@ -37,8 +37,12 @@ class ScalingMixin:
                 if base_height is None:
                     base_height = btn.sizeHint().height()
                     btn.setProperty("base_height", base_height)
-                bw = max(base_width, btn.fontMetrics().boundingRect(btn.text()).width() + 20)
-                bh = base_height
+                bw = max(
+                    base_width,
+                    btn.fontMetrics().boundingRect(btn.text()).width() + 20,
+                )
+                text_height = btn.fontMetrics().boundingRect(btn.text()).height() + 10
+                bh = max(base_height, text_height)
                 btn.setFixedSize(int(bw * factor), int(bh * factor))
 
         for child in self.findChildren(QWidget):


### PR DESCRIPTION
## Summary
- adjust height of buttons in scaling mixin so text fits when fonts are large

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adb166aa483328d6a633907e02df3