### PR TITLE
Allow all users to configure voice

### DIFF
--- a/PROMPTY_3.0/services/permisos.py
+++ b/PROMPTY_3.0/services/permisos.py
@@ -18,7 +18,8 @@ class Permisos:
                 "agregar_datos_curiosos"
             ],
             "usuario": [
-                "ver_comandos"
+                "ver_comandos",
+                "editar_voz"
             ]
         }
 

--- a/PROMPTY_3.0/utils/__init__.py
+++ b/PROMPTY_3.0/utils/__init__.py
@@ -1,6 +1,12 @@
 """Utilidades comunes para PROMPTY 3.0."""
 
 from .helpers import *  # noqa: F401,F403
-from .scaling import ScalingMixin
+
+try:
+    from .scaling import ScalingMixin
+except Exception:  # pragma: no cover - fallback when PyQt is unavailable
+    class ScalingMixin:  # type: ignore
+        """Implementación mínima usada en entornos sin PyQt."""
+        pass
 
 __all__ = ["ScalingMixin"]

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -1024,6 +1024,12 @@ class LoginWindow(ScalingMixin, QWidget):
         self.register_button.setProperty("base_width", self.register_button.sizeHint().width())
         layout.addWidget(self.register_button, alignment=Qt.AlignmentFlag.AlignCenter)
 
+        self.exit_button = QPushButton("Salir")
+        self.exit_button.clicked.connect(self.close)
+        self.exit_button.setProperty("base_height", 30)
+        self.exit_button.setProperty("base_width", self.exit_button.sizeHint().width())
+        layout.addWidget(self.exit_button, alignment=Qt.AlignmentFlag.AlignCenter)
+
         self.setLayout(layout)
         self.apply_scaling()
 

--- a/tests/test_permisos.py
+++ b/tests/test_permisos.py
@@ -9,5 +9,5 @@ from services.permisos import Permisos
 def test_permisos_basicos():
     p = Permisos()
     assert p.tiene_permiso('admin', 'editar_voz')
-    assert not p.tiene_permiso('usuario', 'editar_voz')
+    assert p.tiene_permiso('usuario', 'editar_voz')
     assert 'agregar_comando' in p.listar_permisos('admin')


### PR DESCRIPTION
## Summary
- let regular users modify voice configuration
- provide a fallback ScalingMixin so tests don't require PyQt
- add "Salir" button on the login window
- update permissions test accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af5f0eba083328d0b39127255e9e0