### PR TITLE
Implementar mensaje de acceso denegado

### DIFF
--- a/PROMPTY_2.5/services/asistente_voz.py
+++ b/PROMPTY_2.5/services/asistente_voz.py
@@ -129,4 +129,4 @@ class ServicioVoz:
             if admin:
                 print("🔓 Acceso concedido.")
                 return accion_si_autorizado()
-        return "❌ Acción cancelada o acceso denegado."
+        return "❌ Acceso denegado."

--- a/PROMPTY_2.5/views/terminal.py
+++ b/PROMPTY_2.5/views/terminal.py
@@ -181,7 +181,7 @@ class VistaTerminal:
         clave = input("Contraseña: ").strip()
         admin = self.gestor_roles.autenticar(cif, clave)
         if not admin or not admin.es_admin():
-            print("❌ Credenciales incorrectas.")
+            print("❌ Acceso denegado.")
             return
         print("🔓 Acceso concedido.")
         while True:

--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -133,4 +133,4 @@ class ServicioVoz:
             if admin:
                 print("🔓 Acceso concedido.")
                 return accion_si_autorizado()
-        return "❌ Acción cancelada o acceso denegado."
+        return "❌ Acceso denegado."

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -830,15 +830,17 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         if not self.usuario.es_admin():
             cif, ok = QInputDialog.getText(self, "Modo admin", "CIF del administrador:")
             if not ok:
+                QMessageBox.warning(self, "Error", "Acceso denegado")
                 return
             clave, ok2 = QInputDialog.getText(
                 self, "Modo admin", "Contraseña:", QLineEdit.EchoMode.Password
             )
             if not ok2:
+                QMessageBox.warning(self, "Error", "Acceso denegado")
                 return
             usuario_admin = self.gestor_roles.autenticar(cif.strip(), clave.strip())
             if not usuario_admin or not usuario_admin.es_admin():
-                QMessageBox.warning(self, "Error", "Credenciales incorrectas")
+                QMessageBox.warning(self, "Error", "Acceso denegado")
                 return
         if self.ventana_admin is None:
             self.ventana_admin = AdminWindow(self, self.servicio_voz, self.gestor_roles, usuario_admin)

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -207,7 +207,7 @@ class VistaTerminal:
             clave = input("Contraseña: ").strip()
             admin = self.gestor_roles.autenticar(cif, clave)
             if not admin or not admin.es_admin():
-                print("❌ Credenciales incorrectas.")
+                print("❌ Acceso denegado.")
                 return
         print("🔓 Acceso concedido.")
         while True:


### PR DESCRIPTION
## Summary
- return "Acceso denegado" when admin auth fails
- display warning when cancelling admin login

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b088344e083328e64a8d6dd736466