### PR TITLE
Respect .gitignore when showing project tree

### DIFF
--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -643,13 +643,9 @@ class TreeWindow(ScalingMixin, QWidget):
 
     def cargar_arbol(self):
         root_path = Path(__file__).resolve().parents[1]
-        lineas = []
-        for ruta, dirs, files in os.walk(root_path):
-            nivel = len(Path(ruta).relative_to(root_path).parts)
-            indent = "    " * nivel
-            lineas.append(f"{indent}{Path(ruta).name}/")
-            for f in files:
-                lineas.append(f"{indent}    {f}")
+        from utils.helpers import generar_arbol
+
+        lineas = generar_arbol(root_path)
         self.text.setPlainText("\n".join(lineas))
         
 class PROMTYWindow(ScalingMixin, QMainWindow):

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -161,12 +161,10 @@ class VistaTerminal:
     def mostrar_arbol(self):
         """Imprime la estructura de carpetas del proyecto."""
         root_path = Path(__file__).resolve().parents[2] / "PROMPTY_3.0"
-        for ruta, dirs, files in os.walk(root_path):
-            nivel = len(Path(ruta).relative_to(root_path).parts)
-            indent = "    " * nivel
-            print(f"{indent}{Path(ruta).name}/")
-            for f in files:
-                print(f"{indent}    {f}")
+        from utils.helpers import generar_arbol
+
+        for linea in generar_arbol(root_path):
+            print(linea)
 
     def menu_configuracion_voz(self):
         while True:

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'PROMPTY_3.0'))
+
+from utils.helpers import generar_arbol
+
+
+def test_generar_arbol_gitignore(tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / ".gitignore").write_text("__pycache__/\n*.pyc\n", encoding="utf-8")
+
+    pkg = root / "pkg"
+    pkg.mkdir()
+    cache = pkg / "__pycache__"
+    cache.mkdir()
+    (cache / "mod.pyc").write_text("x", encoding="utf-8")
+    (pkg / "main.py").write_text("print('hi')", encoding="utf-8")
+
+    lines = generar_arbol(pkg)
+    joined = "\n".join(lines)
+    assert "__pycache__" not in joined
+    assert "mod.pyc" not in joined
+    assert "main.py" in joined


### PR DESCRIPTION
## Summary
- add `generar_arbol` helper that reads `.gitignore` with PathSpec
- use the helper in GUI and terminal tree views
- test that generated tree excludes ignored files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0c5ed2f08332bdf425ee58b41654