### PR TITLE
Improve greeting parsing and speech handling

### DIFF
--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -30,8 +30,15 @@ class ServicioVoz:
     def hablar(self, texto):
         texto_sin_colores = quitar_colores(texto)
         texto_limpio = limpiar_emoji(texto_sin_colores)
-        self.engine.say(texto_limpio)
-        self.engine.runAndWait()
+        if self.engine.isBusy():
+            self.engine.stop()
+        try:
+            self.engine.say(texto_limpio)
+            self.engine.runAndWait()
+        except RuntimeError:
+            self.engine.stop()
+            self.engine.say(texto_limpio)
+            self.engine.runAndWait()
         return texto_limpio
 
     def escuchar(self, notify=None):

--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -10,7 +10,7 @@ def interpretar(texto):
     texto = texto.lower().strip()
     texto = texto.replace("en el", "en")  # Normaliza "buscar en el navegador" → "buscar en navegador"
 
-    texto_simple = re.sub(r"[!.,?]", "", texto).strip()
+    texto_simple = re.sub(r"[!¡.,?¿]", "", texto).strip()
     saludos = [
         "hola",
         "hola prompty",

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -35,6 +35,7 @@ class TestInterpretador(unittest.TestCase):
     def test_saludos(self):
         self.assertEqual(interpretar('hola')[0], 'saludo')
         self.assertEqual(interpretar('hola prompty')[0], 'saludo')
+        self.assertEqual(interpretar('¡hola prompty!')[0], 'saludo')
         self.assertNotEqual(interpretar('hola quiero buscar un video')[0], 'saludo')
 
     def test_sinonimos(self):

--- a/tests/test_servicio_voz.py
+++ b/tests/test_servicio_voz.py
@@ -1,0 +1,45 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'PROMPTY_3.0'))
+from services.asistente_voz import ServicioVoz
+
+class DummyEngine:
+    def __init__(self):
+        self.voices = [SimpleNamespace(id='1', name='voice')]
+        self.stopped = False
+        self.busy = False
+        self.last_said = None
+    def say(self, text):
+        self.last_said = text
+        self.busy = True
+    def runAndWait(self):
+        self.busy = False
+    def setProperty(self, *args, **kwargs):
+        pass
+    def getProperty(self, name):
+        if name == 'voices':
+            return self.voices
+    def isBusy(self):
+        return self.busy
+    def stop(self):
+        self.stopped = True
+        self.busy = False
+
+class DummyRecognizer:
+    pass
+
+class DummyUser:
+    rol = 'usuario'
+
+
+def test_hablar_detiene_si_ocupado(monkeypatch):
+    engine = DummyEngine()
+    monkeypatch.setattr('services.asistente_voz.pyttsx3.init', lambda: engine)
+    monkeypatch.setattr('services.asistente_voz.sr.Recognizer', lambda: DummyRecognizer())
+    voz = ServicioVoz(DummyUser())
+    engine.busy = True
+    voz.hablar('hola')
+    assert engine.stopped
+    assert engine.last_said == 'hola'


### PR DESCRIPTION
## Summary
- broaden punctuation normalization when interpreting commands
- stop speech before queuing a new utterance
- test new behaviour of `interpretar` with Spanish punctuation
- test `ServicioVoz` to ensure ongoing speech is interrupted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8511fe44833286f37c8a56cba4c2