### PR TITLE
Fix voice index validation

### DIFF
--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -76,6 +76,8 @@ class ServicioVoz:
         if 0 <= indice < len(voces):
             self.voz_actual = voces[indice].id
             self.engine.setProperty("voice", self.voz_actual)
+            return True
+        return False
 
     def seleccionar_voz(self):
         print("\n🎤 Elige la voz de PROMPTY:")
@@ -96,10 +98,17 @@ class ServicioVoz:
                 print("❌ Entrada inválida. Intenta con un número válido.")
 
     def cambiar_voz(self, indice):
+        voces = self.engine.getProperty("voices")
+        if not 0 <= indice < len(voces):
+            return "❌ Índice de voz inválido."
         if self.tiene_permiso("editar_voz"):
             self.establecer_voz_por_indice(indice)
             return "✔ Voz cambiada con éxito."
-        return self.requiere_autorizacion_admin("cambiar la voz", lambda: self.establecer_voz_por_indice(indice) or "✔ Voz cambiada como administrador.")
+        return self.requiere_autorizacion_admin(
+            "cambiar la voz",
+            lambda: self.establecer_voz_por_indice(indice)
+            or "✔ Voz cambiada como administrador."
+        )
 
     def cambiar_volumen(self, valor):
         if not 0.0 <= valor <= 1.0:

--- a/tests/test_servicio_voz.py
+++ b/tests/test_servicio_voz.py
@@ -43,3 +43,13 @@ def test_hablar_detiene_si_ocupado(monkeypatch):
     voz.hablar('hola')
     assert engine.stopped
     assert engine.last_said == 'hola'
+
+
+def test_cambiar_voz_indice_invalido(monkeypatch):
+    engine = DummyEngine()
+    monkeypatch.setattr('services.asistente_voz.pyttsx3.init', lambda: engine)
+    monkeypatch.setattr('services.asistente_voz.sr.Recognizer', lambda: DummyRecognizer())
+    voz = ServicioVoz(DummyUser())
+    resultado = voz.cambiar_voz(5)
+    assert resultado.startswith('❌')
+    assert voz.voz_actual is None


### PR DESCRIPTION
## Summary
- validate voice index when changing the voice
- unit test for invalid voice index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9113d2b88332b9e6c7281143cd8e