### PR TITLE
fix voice change path

### DIFF
--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -106,9 +106,12 @@ class ServicioVoz:
             return "✔ Voz cambiada con éxito."
         return self.requiere_autorizacion_admin(
             "cambiar la voz",
-            lambda: self.establecer_voz_por_indice(indice)
-            or "✔ Voz cambiada como administrador."
+            lambda: self._forzar_cambio_voz(indice),
         )
+
+    def _forzar_cambio_voz(self, indice):
+        self.establecer_voz_por_indice(indice)
+        return "✔ Voz cambiada como administrador."
 
     def cambiar_volumen(self, valor):
         if not 0.0 <= valor <= 1.0:

--- a/tests/test_servicio_voz.py
+++ b/tests/test_servicio_voz.py
@@ -53,3 +53,17 @@ def test_cambiar_voz_indice_invalido(monkeypatch):
     resultado = voz.cambiar_voz(5)
     assert resultado.startswith('❌')
     assert voz.voz_actual is None
+class DummyAdmin:
+    rol = 'admin'
+
+
+def test_cambiar_voz_con_admin(monkeypatch):
+    engine = DummyEngine()
+    monkeypatch.setattr('services.asistente_voz.pyttsx3.init', lambda: engine)
+    monkeypatch.setattr('services.asistente_voz.sr.Recognizer', lambda: DummyRecognizer())
+    user = SimpleNamespace(rol='guest')
+    voz = ServicioVoz(user, verificar_admin_callback=lambda c, p: DummyAdmin())
+    monkeypatch.setattr('builtins.input', lambda _: 'dummy')
+    resultado = voz.cambiar_voz(0)
+    assert resultado.startswith('✔')
+    assert voz.voz_actual == '1'


### PR DESCRIPTION
## Summary
- fix fallback message in `cambiar_voz`
- add admin helper `_forzar_cambio_voz`
- cover admin path in servicio_voz tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c958ae9d083329abeeb49089fe7cc