### PR TITLE
Fix greeting parsing and voice interruption

### DIFF
--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -10,7 +10,8 @@ def interpretar(texto):
     texto = texto.lower().strip()
     texto = texto.replace("en el", "en")  # Normaliza "buscar en el navegador" → "buscar en navegador"
 
-    texto_simple = re.sub(r"[!.,?]", "", texto).strip()
+    texto_simple = re.sub(r"[!.,?¡¿]", "", texto)
+    texto_simple = re.sub(r"\s+", " ", texto_simple).strip()
     saludos = [
         "hola",
         "hola prompty",

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -35,6 +35,7 @@ class TestInterpretador(unittest.TestCase):
     def test_saludos(self):
         self.assertEqual(interpretar('hola')[0], 'saludo')
         self.assertEqual(interpretar('hola prompty')[0], 'saludo')
+        self.assertEqual(interpretar('¡hola prompty!')[0], 'saludo')
         self.assertNotEqual(interpretar('hola quiero buscar un video')[0], 'saludo')
 
     def test_sinonimos(self):


### PR DESCRIPTION
## Summary
- improve greeting detection for variations like `¡hola prompty!`
- allow voice engine to stop current speech before speaking again
- ensure stopping speech doesn't reset the selected voice
- test greeting with exclamation marks
- handle concurrent speech safely

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c9ed3ac608332a5ad796fb1b8ee0f