### PR TITLE
Mejora control de voz

### DIFF
--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -1,5 +1,7 @@
 import pyttsx3
 import speech_recognition as sr
+import queue
+import threading
 from data import config
 from services.permisos import Permisos
 from utils.helpers import limpiar_emoji, quitar_colores
@@ -18,6 +20,15 @@ class ServicioVoz:
         self.velocidad = config.VELOCIDAD_POR_DEFECTO
         self.volumen = config.VOLUMEN_POR_DEFECTO
 
+        # Control de reproducción de voz
+        self._speech_lock = threading.Lock()
+        self._speech_queue = queue.Queue()
+        self._speech_thread = threading.Thread(
+            target=self._procesar_cola,
+            daemon=True,
+        )
+        self._speech_thread.start()
+
         self.engine.setProperty("rate", self.velocidad)
         self.engine.setProperty("volume", self.volumen)
 
@@ -27,18 +38,72 @@ class ServicioVoz:
         except Exception:
             pass
 
+    def _procesar_cola(self):
+        """Hilo de reproducción que procesa la cola de frases."""
+        while True:
+            texto = self._speech_queue.get()
+            if texto is None:
+                break
+            self.engine.say(texto)
+            try:
+                self.engine.runAndWait()
+            except Exception as e:  # pragma: no cover - no audio backend in tests
+                print(f"⚠️ Error en motor de voz: {e}. Reiniciando...")
+                try:
+                    self.engine.stop()
+                except Exception:
+                    pass
+                self.engine = pyttsx3.init()
+                self.engine.setProperty("voice", self.voz_actual)
+                self.engine.setProperty("rate", self.velocidad)
+                self.engine.setProperty("volume", self.volumen)
+            finally:
+                self._speech_queue.task_done()
+
     def hablar(self, texto):
+        """Reproduce ``texto`` deteniendo cualquier reproducción en curso."""
         texto_sin_colores = quitar_colores(texto)
         texto_limpio = limpiar_emoji(texto_sin_colores)
-        self.engine.say(texto_limpio)
-        self.engine.runAndWait()
+
+        with self._speech_lock:
+            # Detener la reproducción actual y limpiar la cola
+            if self._speech_thread.is_alive():
+                self.engine.stop()
+                # Reiniciar el motor para evitar que se quede en un estado
+                # inconsistente tras varias interrupciones
+                self.engine = pyttsx3.init()
+                self.engine.setProperty("voice", self.voz_actual)
+                self.engine.setProperty("rate", self.velocidad)
+                self.engine.setProperty("volume", self.volumen)
+            while not self._speech_queue.empty():
+                try:
+                    self._speech_queue.get_nowait()
+                    self._speech_queue.task_done()
+                except queue.Empty:
+                    break
+
+
+            if not self._speech_thread.is_alive():
+                self._speech_thread = threading.Thread(
+                    target=self._procesar_cola,
+                    daemon=True,
+                )
+                self._speech_thread.start()
+
+            self._speech_queue.put(texto_limpio)
         return texto_limpio
+
+    def esperar_fin(self):
+        """Bloquea hasta que termine la reproducción en curso."""
+        self._speech_queue.join()
 
     def escuchar(self, notify=None):
         """Escucha desde el micrófono y devuelve el texto reconocido.
         Si se proporciona ``notify`` se llamará con el mensaje de escucha en
         lugar de imprimirlo en la terminal. Devuelve ``None`` si no se entiende
         o ``"__error_red"`` si ocurre un problema de conexión."""
+        # Asegura que no haya reproducción en curso antes de escuchar
+        self.esperar_fin()
         with sr.Microphone() as source:
             if notify:
                 notify("🎙️ Escuchando...")

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Cada versión cuenta con su propio archivo principal:
 - **Prompty1.0**: scripts iniciales ubicados en `Prompty1.0`. Ejecuta por ejemplo `python Prompty1.0.py` o `Prompty1.2.py` según el script que quieras probar.
 - **PROMPTY_2.0**: versión modularizada. Corre `python PROMPTY_2.0/main.py`.
 - **PROMPTY_2.5**: prototipo con estructura de modelos y servicios.
-- **PROMPTY_3.0**: versión actual con GUI funcional, reconocimiento de voz y ventanas de configuración y ayuda. Ejecuta `python PROMPTY_3.0/main.py` y elige la opción gráfica. La interfaz ahora escala mejor en pantalla completa.
+- **PROMPTY_3.0**: versión actual con GUI funcional, reconocimiento de voz y ventanas de configuración y ayuda. Ejecuta `python PROMPTY_3.0/main.py` y elige la opción gráfica. La interfaz ahora escala mejor en pantalla completa y la voz se puede interrumpir (incluso al enviar varios comandos seguidos) sin perder la configuración.
 
 Asegúrate de usar Python 3.13
 


### PR DESCRIPTION
## Summary
- allow interrupting voice playback to avoid overlapping speeches
- ensure engine settings persist after stopping
- mention the new feature in the README
- catch voice engine errors so the thread can recover and restart if needed
- reinitialize the voice engine after stopping to keep it stable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d8e95c08883328f4abbad56e0839f