### PR TITLE
Fix voice interruption behavior

### DIFF
--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -34,6 +34,15 @@ class ServicioVoz:
         self.engine.runAndWait()
         return texto_limpio
 
+    def detener(self):
+        """Detiene la reproducción actual manteniendo la configuración."""
+        if self.engine.isBusy():
+            self.engine.stop()
+            if self.voz_actual:
+                self.engine.setProperty("voice", self.voz_actual)
+            self.engine.setProperty("rate", self.velocidad)
+            self.engine.setProperty("volume", self.volumen)
+
     def escuchar(self, notify=None):
         """Escucha desde el micrófono y devuelve el texto reconocido.
         Si se proporciona ``notify`` se llamará con el mensaje de escucha en

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -867,6 +867,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         self.ventana_tree.show()
 
     def activate_voice(self):
+        self.servicio_voz.detener()
         mensaje_original = self.label.text()
         self.label.setText("\ud83c\udf99\ufe0f Escuchando...")
         
@@ -887,10 +888,12 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
     def process_command(self):
         texto = self.command_input.text().strip()
         if texto:
+            self.servicio_voz.detener()
             self.ejecutar_comando_desde_texto(texto)
             self.command_input.clear()
 
     def ejecutar_comando_desde_texto(self, texto):
+        self.servicio_voz.detener()
         comando, argumentos = interpretar(texto)
         self.text_output.clear()
 


### PR DESCRIPTION
## Summary
- add `ServicioVoz.detener` to stop playback preserving voice settings
- stop ongoing speech when starting a new command from the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9a4ef6108332b1f3317b2154d34e