### PR TITLE
Improve time/date commands and GUI feedback

### DIFF
--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -45,6 +45,15 @@ def interpretar(texto):
     ]):
         return "reproducir_musica", None
 
+    if re.search(r"\bfecha\b", texto) and re.search(r"\bhora\b", texto):
+        return "fecha_hora", None
+    if re.search(r"\bfecha\b", texto):
+        return "fecha", None
+    if re.search(r"\bhora\b", texto):
+        return "hora", None
+    if re.search(r"\btiempo\b", texto):
+        return "fecha_hora", None
+
     numero_comandos = {
         ("1", "uno"): "fecha_hora",
         ("2", "dos"): "abrir_con_opcion",
@@ -63,7 +72,7 @@ def interpretar(texto):
             return comando, None
 
     palabras_clave = {
-        ("hora", "fecha", "tiempo"): "fecha_hora",
+        ("tiempo",): "fecha_hora",
         ("carpeta", "folder", "directorio"): "abrir_carpeta",
         ("archivo", "documento", "fichero", "aplicacion", "aplicación", "app"): "abrir_archivo",
         ("abrir", "abre", "ejecuta"): "abrir_con_opcion",

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -889,6 +889,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         texto = self.command_input.text().strip()
         if texto:
             self.servicio_voz.detener()
+            self.text_output.append("\U0001F5E3\ufe0f Entendí: " + texto)
             self.ejecutar_comando_desde_texto(texto)
             self.command_input.clear()
 

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -42,6 +42,11 @@ class TestInterpretador(unittest.TestCase):
         self.assertEqual(interpretar('abre un documento')[0], 'abrir_archivo')
         self.assertEqual(interpretar('exit')[0], 'salir')
 
+    def test_fechas_horas(self):
+        self.assertEqual(interpretar('fecha y hora')[0], 'fecha_hora')
+        self.assertEqual(interpretar('que hora es')[0], 'hora')
+        self.assertEqual(interpretar('cual es la fecha')[0], 'fecha')
+
     def test_desconocido(self):
         self.assertEqual(interpretar('xyz')[0], 'comando_no_reconocido')
 


### PR DESCRIPTION
## Summary
- refine `interpretar` to distinguish between `fecha`, `hora` and `fecha y hora`
- display "Entendí" messages for typed commands in the GUI
- cover new behaviour with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686184f6971c8332a7ecdaa9a6d5042a