### PR TITLE
Improve code organization

### DIFF
--- a/PROMPTY_3.0/services/autenticacion.py
+++ b/PROMPTY_3.0/services/autenticacion.py
@@ -1,0 +1,28 @@
+"""Funciones de autenticación compartidas entre las interfaces."""
+from typing import Callable, Tuple, Optional
+
+from services.gestor_roles import GestorRoles
+from models.usuario import Usuario
+
+
+class ServicioAutenticacion:
+    """Centraliza la lógica para verificar credenciales de administrador."""
+
+    def __init__(self, gestor_roles: GestorRoles | None = None):
+        self.gestor_roles = gestor_roles or GestorRoles()
+
+    def autenticar_admin(
+        self,
+        usuario: Usuario,
+        solicitar_credenciales: Callable[[], Tuple[str | None, str | None]],
+    ) -> Optional[Usuario]:
+        """Devuelve un usuario administrador válido o ``None`` si falla."""
+        admin = usuario
+        if not usuario.es_admin():
+            cif, clave = solicitar_credenciales()
+            if not cif or not clave:
+                return None
+            admin = self.gestor_roles.autenticar(cif.strip(), clave.strip())
+        if admin and admin.es_admin():
+            return admin
+        return None

--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -1,3 +1,5 @@
+"""Gestiona la asociación de comandos con sus funciones ejecutables."""
+
 from services.comandos_basicos import ComandosBasicos
 
 
@@ -8,19 +10,19 @@ class GestorComandos:
         self.basicos = ComandosBasicos()
         self.usuario_actual = usuario_actual
         self._acciones = {
-            "fecha": lambda a, e: self.basicos.mostrar_fecha(),
-            "hora": lambda a, e: self.basicos.mostrar_hora(),
-            "fecha_hora": lambda a, e: self.basicos.mostrar_fecha_hora(),
-            "abrir_carpeta": lambda a, e: self.basicos.abrir_carpeta(a) if a else self.basicos.abrir_con_opcion(tipo="carpeta", entrada_manual_func=e),
-            "abrir_archivo": lambda a, e: self.basicos.abrir_con_opcion(tipo="archivo", entrada_manual_func=e),
-            "abrir_con_opcion": lambda a, e: self.basicos.abrir_con_opcion(entrada_manual_func=e),
-            "buscar_en_youtube": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(destino_predefinido="youtube", entrada_manual_func=e if not a else None),
-            "buscar_en_navegador": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=e),
-            "buscar_general": lambda a, e: self.basicos.buscar_en_navegador_con_opcion(destino_predefinido="navegador", entrada_manual_func=e),
-            "reproducir_musica": lambda a, e: self.basicos.reproducir_musica(entrada_manual_func=e),
-            "dato_curioso": lambda a, e: self.basicos.mostrar_dato_curioso(),
-            "info_programa": lambda a, e: self.basicos.info_sistema(entrada_manual_func=e),
-            "saludo": lambda a, e: self.basicos.responder_saludo(),
+            "fecha": self._accion_fecha,
+            "hora": self._accion_hora,
+            "fecha_hora": self._accion_fecha_hora,
+            "abrir_carpeta": self._accion_abrir_carpeta,
+            "abrir_archivo": self._accion_abrir_archivo,
+            "abrir_con_opcion": self._accion_abrir_con_opcion,
+            "buscar_en_youtube": self._accion_buscar_en_youtube,
+            "buscar_en_navegador": self._accion_buscar_en_navegador,
+            "buscar_general": self._accion_buscar_general,
+            "reproducir_musica": self._accion_reproducir_musica,
+            "dato_curioso": self._accion_dato_curioso,
+            "info_programa": self._accion_info_programa,
+            "saludo": self._accion_saludo,
         }
 
     def establecer_usuario(self, usuario):
@@ -39,3 +41,50 @@ class GestorComandos:
             "❌ Comando no reconocido. "
             "Consulta la sección de ayuda para conocer las opciones disponibles."
         )
+
+    # Funciones de acción extraídas del diccionario ------------------------
+    def _accion_fecha(self, args, entrada_func):
+        return self.basicos.mostrar_fecha()
+
+    def _accion_hora(self, args, entrada_func):
+        return self.basicos.mostrar_hora()
+
+    def _accion_fecha_hora(self, args, entrada_func):
+        return self.basicos.mostrar_fecha_hora()
+
+    def _accion_abrir_carpeta(self, args, entrada_func):
+        if args:
+            return self.basicos.abrir_carpeta(args)
+        return self.basicos.abrir_con_opcion(tipo="carpeta", entrada_manual_func=entrada_func)
+
+    def _accion_abrir_archivo(self, args, entrada_func):
+        return self.basicos.abrir_con_opcion(tipo="archivo", entrada_manual_func=entrada_func)
+
+    def _accion_abrir_con_opcion(self, args, entrada_func):
+        return self.basicos.abrir_con_opcion(entrada_manual_func=entrada_func)
+
+    def _accion_buscar_en_youtube(self, args, entrada_func):
+        manual = entrada_func if not args else None
+        return self.basicos.buscar_en_navegador_con_opcion(
+            destino_predefinido="youtube", entrada_manual_func=manual
+        )
+
+    def _accion_buscar_en_navegador(self, args, entrada_func):
+        return self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=entrada_func)
+
+    def _accion_buscar_general(self, args, entrada_func):
+        return self.basicos.buscar_en_navegador_con_opcion(
+            destino_predefinido="navegador", entrada_manual_func=entrada_func
+        )
+
+    def _accion_reproducir_musica(self, args, entrada_func):
+        return self.basicos.reproducir_musica(entrada_manual_func=entrada_func)
+
+    def _accion_dato_curioso(self, args, entrada_func):
+        return self.basicos.mostrar_dato_curioso()
+
+    def _accion_info_programa(self, args, entrada_func):
+        return self.basicos.info_sistema(entrada_manual_func=entrada_func)
+
+    def _accion_saludo(self, args, entrada_func):
+        return self.basicos.responder_saludo()

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -1,3 +1,5 @@
+"""Interfaz gráfica principal de PROMPTY construida con PyQt."""
+
 import os
 import sys
 from pathlib import Path
@@ -34,6 +36,7 @@ from PyQt6.QtWidgets import (
 from services.asistente_voz import ServicioVoz
 from services.gestor_comandos import GestorComandos
 from services.gestor_roles import GestorRoles
+from services.autenticacion import ServicioAutenticacion
 from services.interpretador import interpretar
 from utils import ScalingMixin
 from utils.helpers import quitar_colores
@@ -655,6 +658,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         self.usuario = usuario
         self.logout_callback = logout_callback
         self.gestor_roles = GestorRoles()
+        self.auth_service = ServicioAutenticacion(self.gestor_roles)
         self.servicio_voz = ServicioVoz(usuario, verificar_admin_callback=self.gestor_roles.autenticar)
         self.gestor_comandos = GestorComandos(usuario)
         self.setWindowTitle("PROMTY - Asistente de Voz")
@@ -832,24 +836,21 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             contrario.
         """
 
-        usuario_admin = self.usuario
-        if not self.usuario.es_admin():
+        def pedir():
             cif, ok = QInputDialog.getText(self, "Modo admin", "CIF del administrador:")
             if not ok:
-                QMessageBox.warning(self, "Error", "Acceso denegado: operación cancelada")
-                return False
-
+                return None, None
             clave, ok2 = QInputDialog.getText(
                 self, "Modo admin", "Contraseña:", QLineEdit.EchoMode.Password
             )
             if not ok2:
-                QMessageBox.warning(self, "Error", "Acceso denegado: operación cancelada")
-                return False
+                return None, None
+            return cif.strip(), clave.strip()
 
-            usuario_admin = self.gestor_roles.autenticar(cif.strip(), clave.strip())
-            if not usuario_admin or not usuario_admin.es_admin():
-                QMessageBox.warning(self, "Error", "Acceso denegado: credenciales incorrectas")
-                return False
+        usuario_admin = self.auth_service.autenticar_admin(self.usuario, pedir)
+        if not usuario_admin:
+            QMessageBox.warning(self, "Error", "Acceso denegado")
+            return False
 
         if self.ventana_admin is None:
             self.ventana_admin = AdminWindow(
@@ -895,6 +896,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
 
     def ejecutar_comando_desde_texto(self, texto):
         self.servicio_voz.detener()
+        # Obtener la acción y limpiar la salida previa
         comando, argumentos = interpretar(texto)
         self.text_output.clear()
 
@@ -920,6 +922,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             self.ver_arbol_programa()
             respuesta = "Mostrando estructura del proyecto..."
         else:
+            # Llamadas que requieren interacción del usuario
             interactivos = {
                 "abrir_carpeta",
                 "abrir_con_opcion",
@@ -934,6 +937,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             else:
                 respuesta = self.gestor_comandos.ejecutar_comando(comando, argumentos)
 
+        # Mostrar respuesta final al usuario
         self.mostrar_respuesta(respuesta)
 
     def mostrar_respuesta(self, respuesta: str):

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -1,9 +1,12 @@
+"""Vista en terminal para interactuar con PROMPTY."""
+
 from pathlib import Path
 
 from colorama import Fore, Style
 from services.asistente_voz import ServicioVoz
 from services.gestor_comandos import GestorComandos
 from services.gestor_roles import GestorRoles
+from services.autenticacion import ServicioAutenticacion
 from services.interpretador import interpretar
 from utils.helpers import limpiar_pantalla, quitar_colores
 
@@ -12,6 +15,7 @@ class VistaTerminal:
     def __init__(self, usuario):
         self.usuario = usuario
         self.gestor_roles = GestorRoles()
+        self.auth_service = ServicioAutenticacion(self.gestor_roles)
         self.asistente_voz = ServicioVoz(usuario, verificar_admin_callback=self.gestor_roles.autenticar)
         self.gestor_comandos = GestorComandos(usuario)
         self.modo_respuesta = "texto"
@@ -202,14 +206,15 @@ class VistaTerminal:
 
     def menu_admin(self):
         print("\n🔐 MODO ADMINISTRADOR")
-        admin = self.usuario
-        if not self.usuario.es_admin():
+        def pedir():
             cif = input("CIF del administrador: ").strip()
             clave = input("Contraseña: ").strip()
-            admin = self.gestor_roles.autenticar(cif, clave)
-            if not admin or not admin.es_admin():
-                print("❌ Acceso denegado.")
-                return
+            return cif, clave
+
+        admin = self.auth_service.autenticar_admin(self.usuario, pedir)
+        if not admin:
+            print("❌ Acceso denegado.")
+            return
         print("🔓 Acceso concedido.")
         while True:
             print("\n⚙️ OPCIONES DE ADMINISTRADOR")


### PR DESCRIPTION
## Summary
- add `ServicioAutenticacion` for shared admin checks
- refactor `GestorComandos` by extracting actions to methods
- use the authentication service in GUI and terminal
- annotate long methods with short comments
- add module docstrings for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618c5457dc833285b494640cefc5e7