### PR TITLE
Update GUI listening flow

### DIFF
--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -871,7 +871,10 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         self.servicio_voz.detener()
         mensaje_original = self.label.text()
         self.label.setText("\ud83c\udf99\ufe0f Escuchando...")
-        
+
+        # Limpiar la salida para mostrar el estado de escucha
+        self.text_output.clear()
+
         def notify_gui(msg):
             self.text_output.append(msg)
             QApplication.processEvents()
@@ -883,8 +886,11 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             self.text_output.append("\u274c No se entendió el comando")
             self.servicio_voz.hablar("No se entendió el comando")
             return
+
+        # Mostrar lo entendido y dar tiempo a leerlo antes de procesar
         self.text_output.append(f"\ud83d\udde3\ufe0f Entendí: {texto}")
-        self.ejecutar_comando_desde_texto(texto)
+        QApplication.processEvents()
+        QTimer.singleShot(1500, lambda: self.ejecutar_comando_desde_texto(texto))
 
     def process_command(self):
         texto = self.command_input.text().strip()


### PR DESCRIPTION
## Summary
- clear text box when listening begins
- delay processing so user can read the recognized command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861995736588332b57b0508633536b2