### PR TITLE
Improve voice output for dates

### DIFF
--- a/tests/test_asistente_voz.py
+++ b/tests/test_asistente_voz.py
@@ -55,3 +55,11 @@ def test_normalizar_numeros(monkeypatch):
     voz = av.ServicioVoz(usuario)
     texto = voz.hablar("Tengo 1000 pesos")
     assert "mil" in texto
+
+
+def test_fecha_hora_natural(monkeypatch):
+    usuario = SimpleNamespace(rol="usuario")
+    voz = av.ServicioVoz(usuario)
+    texto = voz.hablar("\U0001F4C6 02/01/2020 \U0001F552 15:30:00")
+    assert "hoy es" in texto.lower()
+    assert "tres" in texto.lower()


### PR DESCRIPTION
## Summary
- detect date+time responses in ServicioVoz
- convert them to natural language for the TTS engine
- test that the spoken date/time is human friendly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619ade1a248332b4ad44e21b29ba4f