### PR TITLE
Agregar pausa inicial en síntesis de voz

### DIFF
--- a/PROMPTY_3.0/data/config.py
+++ b/PROMPTY_3.0/data/config.py
@@ -6,6 +6,9 @@ VELOCIDAD_POR_DEFECTO = 150
 # Volumen (0.0 a 1.0)
 VOLUMEN_POR_DEFECTO = 0.9
 
+# Espera en segundos antes de reproducir la voz
+ESPERA_INICIAL_VOZ = 0.3
+
 # Fuente y tamaño de letra predeterminados para la interfaz
 FUENTE_POR_DEFECTO = "Arial Rounded MT"
 TAMANO_LETRA_POR_DEFECTO = 14

--- a/PROMPTY_3.0/services/asistente_voz.py
+++ b/PROMPTY_3.0/services/asistente_voz.py
@@ -1,6 +1,7 @@
 import pyttsx3
 import speech_recognition as sr
 import re
+import time
 from num2words import num2words
 from data import config
 from services.permisos import Permisos
@@ -98,6 +99,8 @@ class ServicioVoz:
         # Garantizar que no haya otro loop de pyttsx3 activo y que el motor exista
         self.detener()
         self._ensure_engine()
+        # Dar tiempo para que el motor se inicialice correctamente
+        time.sleep(config.ESPERA_INICIAL_VOZ)
         try:
             self.engine.say(texto_final)
             self.engine.runAndWait()


### PR DESCRIPTION
## Summary
- add small delay constant in config
- wait before speaking to avoid clipped audio
- update ServicioVoz accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619d305d748332bc66169165742356