### PR TITLE
Corrige nombres de comandos de búsqueda

### DIFF
--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -18,8 +18,8 @@ class GestorComandos:
             "abrir_archivo": self._accion_abrir_archivo,
             "abrir_con_opcion": self._accion_abrir_con_opcion,
             "buscar_en_youtube": self._accion_buscar_en_youtube,
-            "buscar_en_navegador": self._accion_buscar_en_navegador,
-            "buscar_general": self._accion_buscar_general,
+            "buscar_en_navegador_interactivo": self._accion_buscar_en_navegador_interactivo,
+            "buscar_en_navegador_directo": self._accion_buscar_en_navegador_directo,
             "reproducir_musica": self._accion_reproducir_musica,
             "dato_curioso": self._accion_dato_curioso,
             "info_programa": self._accion_info_programa,
@@ -73,10 +73,10 @@ class GestorComandos:
             destino_predefinido="youtube", entrada_manual_func=manual
         )
 
-    def _accion_buscar_en_navegador(self, args, entrada_func):
+    def _accion_buscar_en_navegador_interactivo(self, args, entrada_func):
         return self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=entrada_func)
 
-    def _accion_buscar_general(self, args, entrada_func):
+    def _accion_buscar_en_navegador_directo(self, args, entrada_func):
         return self.basicos.buscar_en_navegador_con_opcion(
             destino_predefinido="navegador", entrada_manual_func=entrada_func
         )

--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -27,13 +27,12 @@ def interpretar(texto):
         if "youtube" in texto:
             return "buscar_en_youtube", None
         elif "google" in texto or "navegador" in texto:
-            # Si el usuario especifica google o navegador, ya sabemos el destino
-            # por lo que sólo se debe preguntar si quiere buscar un término o
-            # ingresar una URL.
-            return "buscar_en_navegador", None
+            # Si el usuario especifica google o navegador, se asume que
+            # desea realizar la búsqueda directamente en ese destino.
+            return "buscar_en_navegador_directo", None
         else:
             # El usuario dijo "buscar" pero no indicó destino; se pregunta dónde.
-            return "buscar_general", None
+            return "buscar_en_navegador_interactivo", None
 
     if any(p in texto for p in [
         "musica",
@@ -60,7 +59,7 @@ def interpretar(texto):
     numero_comandos = {
         ("1", "uno"): "fecha_hora",
         ("2", "dos"): "abrir_con_opcion",
-        ("3", "tres"): "buscar_general",
+        ("3", "tres"): "buscar_en_navegador_directo",
         ("4", "cuatro"): "reproducir_musica",
         ("5", "cinco"): "dato_curioso",
         ("6", "seis"): "info_programa",
@@ -80,8 +79,11 @@ def interpretar(texto):
         ("archivo", "documento", "fichero", "aplicacion", "aplicación", "app"): "abrir_archivo",
         ("abrir", "abre", "ejecuta"): "abrir_con_opcion",
         ("youtube",): "buscar_en_youtube",
-        ("navegador", "google", "internet", "web", "explorador"): "buscar_en_navegador",
-        ("buscar", "investigar", "consultar"): "buscar_general",
+        # Si la palabra clave indica explícitamente "navegador" o "google",
+        # se asume búsqueda directa en el navegador.
+        ("navegador", "google", "internet", "web", "explorador"): "buscar_en_navegador_directo",
+        # Palabras genéricas para buscar sin destino definido.
+        ("buscar", "investigar", "consultar"): "buscar_en_navegador_interactivo",
         (
             "musica",
             "música",

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -932,9 +932,9 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             interactivos = {
                 "abrir_carpeta",
                 "abrir_con_opcion",
-                "buscar_en_navegador",
+                "buscar_en_navegador_interactivo",
                 "buscar_en_youtube",
-                "buscar_general",
+                "buscar_en_navegador_directo",
                 "info_programa",
                 "reproducir_musica",
             }

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -73,9 +73,9 @@ class VistaTerminal:
             comandos_interactivos = [
                 "abrir_carpeta",
                 "abrir_con_opcion",
-                "buscar_en_navegador",
+                "buscar_en_navegador_interactivo",
                 "buscar_en_youtube",
-                "buscar_general",
+                "buscar_en_navegador_directo",
                 "reproducir_musica",
             ]
             if comando in comandos_interactivos:

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -21,8 +21,8 @@ class TestInterpretador(unittest.TestCase):
 
     def test_busquedas(self):
         self.assertEqual(interpretar('buscar receta en youtube')[0], 'buscar_en_youtube')
-        self.assertEqual(interpretar('buscar fotos en google')[0], 'buscar_general')
-        self.assertEqual(interpretar('buscar un archivo')[0], 'buscar_en_navegador')
+        self.assertEqual(interpretar('buscar fotos en google')[0], 'buscar_en_navegador_directo')
+        self.assertEqual(interpretar('buscar un archivo')[0], 'buscar_en_navegador_interactivo')
         self.assertEqual(interpretar('escuchar musica')[0], 'reproducir_musica')
         self.assertEqual(interpretar('poner cancion')[0], 'reproducir_musica')
         self.assertEqual(interpretar('oir canciones')[0], 'reproducir_musica')


### PR DESCRIPTION
## Summary
- renombra los comandos `buscar_general` y `buscar_en_navegador` para reflejar mejor su función
- ajusta el interpretador y vistas a los nuevos nombres
- actualiza las pruebas unitarias

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861a1b505808332977d435163d1ef68