### PR TITLE
Rename search commands and recognize admin phrase

### DIFF
--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -18,8 +18,8 @@ class GestorComandos:
             "abrir_archivo": self._accion_abrir_archivo,
             "abrir_con_opcion": self._accion_abrir_con_opcion,
             "buscar_en_youtube": self._accion_buscar_en_youtube,
-            "buscar_en_navegador_interactivo": self._accion_buscar_en_navegador_interactivo,
-            "buscar_en_navegador_directo": self._accion_buscar_en_navegador_directo,
+            "buscar_general": self._accion_buscar_general,
+            "buscar_en_navegador": self._accion_buscar_en_navegador,
             "reproducir_musica": self._accion_reproducir_musica,
             "dato_curioso": self._accion_dato_curioso,
             "info_programa": self._accion_info_programa,
@@ -73,10 +73,10 @@ class GestorComandos:
             destino_predefinido="youtube", entrada_manual_func=manual
         )
 
-    def _accion_buscar_en_navegador_interactivo(self, args, entrada_func):
+    def _accion_buscar_general(self, args, entrada_func):
         return self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=entrada_func)
 
-    def _accion_buscar_en_navegador_directo(self, args, entrada_func):
+    def _accion_buscar_en_navegador(self, args, entrada_func):
         return self.basicos.buscar_en_navegador_con_opcion(
             destino_predefinido="navegador", entrada_manual_func=entrada_func
         )

--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -23,16 +23,19 @@ def interpretar(texto):
     if texto_simple in saludos:
         return "saludo", None
 
+    if "administrador" in texto and "funciones" in texto:
+        return "modo_admin", None
+
     if "buscar" in texto:
         if "youtube" in texto:
             return "buscar_en_youtube", None
         elif "google" in texto or "navegador" in texto:
             # Si el usuario especifica google o navegador, se asume que
             # desea realizar la búsqueda directamente en ese destino.
-            return "buscar_en_navegador_directo", None
+            return "buscar_en_navegador", None
         else:
             # El usuario dijo "buscar" pero no indicó destino; se pregunta dónde.
-            return "buscar_en_navegador_interactivo", None
+            return "buscar_general", None
 
     if any(p in texto for p in [
         "musica",
@@ -59,7 +62,7 @@ def interpretar(texto):
     numero_comandos = {
         ("1", "uno"): "fecha_hora",
         ("2", "dos"): "abrir_con_opcion",
-        ("3", "tres"): "buscar_en_navegador_directo",
+        ("3", "tres"): "buscar_en_navegador",
         ("4", "cuatro"): "reproducir_musica",
         ("5", "cinco"): "dato_curioso",
         ("6", "seis"): "info_programa",
@@ -81,9 +84,9 @@ def interpretar(texto):
         ("youtube",): "buscar_en_youtube",
         # Si la palabra clave indica explícitamente "navegador" o "google",
         # se asume búsqueda directa en el navegador.
-        ("navegador", "google", "internet", "web", "explorador"): "buscar_en_navegador_directo",
+        ("navegador", "google", "internet", "web", "explorador"): "buscar_en_navegador",
         # Palabras genéricas para buscar sin destino definido.
-        ("buscar", "investigar", "consultar"): "buscar_en_navegador_interactivo",
+        ("buscar", "investigar", "consultar"): "buscar_general",
         (
             "musica",
             "música",
@@ -100,6 +103,14 @@ def interpretar(texto):
         ("curioso", "dato", "curiosidad", "sabias"): "dato_curioso",
         ("programa", "creador", "información", "informacion", "acerca", "sobre"): "info_programa",
         ("usuario", "perfil", "cuenta"): "editar_usuario",
+        (
+            "funciones de administrador",
+            "funciones del administrador",
+            "abre el administrador",
+            "abre las funciones de administrador",
+            "abrir administrador",
+            "abrir las funciones de administrador",
+        ): "modo_admin",
         ("ayuda", "opciones", "menu", "ayudar"): "ayuda",
         ("tree", "árbol", "arbol", "estructura", "directorios", "mapa"): "ver_arbol",
         ("salir", "cerrar", "adios", "terminar", "exit"): "salir",

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -932,9 +932,9 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             interactivos = {
                 "abrir_carpeta",
                 "abrir_con_opcion",
-                "buscar_en_navegador_interactivo",
+                "buscar_general",
                 "buscar_en_youtube",
-                "buscar_en_navegador_directo",
+                "buscar_en_navegador",
                 "info_programa",
                 "reproducir_musica",
             }

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -73,9 +73,9 @@ class VistaTerminal:
             comandos_interactivos = [
                 "abrir_carpeta",
                 "abrir_con_opcion",
-                "buscar_en_navegador_interactivo",
+                "buscar_general",
                 "buscar_en_youtube",
-                "buscar_en_navegador_directo",
+                "buscar_en_navegador",
                 "reproducir_musica",
             ]
             if comando in comandos_interactivos:

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -21,11 +21,15 @@ class TestInterpretador(unittest.TestCase):
 
     def test_busquedas(self):
         self.assertEqual(interpretar('buscar receta en youtube')[0], 'buscar_en_youtube')
-        self.assertEqual(interpretar('buscar fotos en google')[0], 'buscar_en_navegador_directo')
-        self.assertEqual(interpretar('buscar un archivo')[0], 'buscar_en_navegador_interactivo')
+        self.assertEqual(interpretar('buscar fotos en google')[0], 'buscar_en_navegador')
+        self.assertEqual(interpretar('buscar un archivo')[0], 'buscar_general')
         self.assertEqual(interpretar('escuchar musica')[0], 'reproducir_musica')
         self.assertEqual(interpretar('poner cancion')[0], 'reproducir_musica')
         self.assertEqual(interpretar('oir canciones')[0], 'reproducir_musica')
+
+    def test_admin_frase(self):
+        resultado = interpretar('abre las funciones de administrador')[0]
+        self.assertEqual(resultado, 'modo_admin')
 
     def test_arbol(self):
         self.assertEqual(interpretar('tree')[0], 'ver_arbol')


### PR DESCRIPTION
## Summary
- rename `buscar_en_navegador_directo` to `buscar_en_navegador`
- rename `buscar_en_navegador_interactivo` to `buscar_general`
- detect phrases about opening admin functions
- update GUI and terminal to use new command names
- update interpreter tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ec1a6d788332a5e9b2307f057290