### PR TITLE
Resize exit buttons

### DIFF
--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -765,10 +765,11 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         self.button_salir.setStyleSheet(
             "background-color: #ff6347; color: white; border-radius: 10px;"
         )
-        self.button_salir.setProperty("base_height", 40)
-        self.button_salir.setProperty(
-            "base_width", self.button_salir.sizeHint().width()
-        )
+        # Hacemos el botón de salida más grande por defecto
+        self.button_salir.setProperty("base_height", 60)
+        # Aumentamos también el ancho base para que sea más visible
+        base_width_salir = max(150, self.button_salir.sizeHint().width())
+        self.button_salir.setProperty("base_width", base_width_salir)
         self.button_salir.clicked.connect(self.close)
         main_layout.addWidget(self.button_salir, alignment=Qt.AlignmentFlag.AlignCenter)
 
@@ -1089,8 +1090,10 @@ class LoginWindow(ScalingMixin, QWidget):
 
         self.exit_button = QPushButton("Salir")
         self.exit_button.clicked.connect(self.close)
-        self.exit_button.setProperty("base_height", 30)
-        self.exit_button.setProperty("base_width", self.exit_button.sizeHint().width())
+        # Botón de salida más grande para facilitar su pulsación
+        self.exit_button.setProperty("base_height", 50)
+        base_exit_width = max(120, self.exit_button.sizeHint().width())
+        self.exit_button.setProperty("base_width", base_exit_width)
         layout.addWidget(self.exit_button, alignment=Qt.AlignmentFlag.AlignCenter)
 
         self.setLayout(layout)


### PR DESCRIPTION
## Summary
- update `Salir` button in the main window to use larger base sizes
- update login screen exit button to be bigger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861efdafac48332a39c7260b1a4a6dc