### PR TITLE
Improve admin keywords and dark mode

### DIFF
--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -66,10 +66,10 @@ def interpretar(texto):
         ("4", "cuatro"): "reproducir_musica",
         ("5", "cinco"): "dato_curioso",
         ("6", "seis"): "info_programa",
-        ("7", "siete", "administrador", "modo admin"): "modo_admin",
+        ("7", "siete"): "modo_admin",
         ("8", "ocho"): "editar_usuario",
-        ("9", "nueve", "cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
-        ("10", "diez", "salir", "cerrar"): "salir",
+        ("9", "nueve"): "cerrar_sesion",
+        ("10", "diez"): "salir",
     }
 
     for claves, comando in numero_comandos.items():
@@ -111,10 +111,11 @@ def interpretar(texto):
             "abrir administrador",
             "abrir las funciones de administrador",
         ): "modo_admin",
+        ("admin", "administrador"): "modo_admin",
         ("ayuda", "opciones", "menu", "ayudar"): "ayuda",
         ("tree", "árbol", "arbol", "estructura", "directorios", "mapa"): "ver_arbol",
-        ("salir", "cerrar", "adios", "terminar", "exit"): "salir",
         ("cerrar sesión", "cerrar sesion", "logout"): "cerrar_sesion",
+        ("salir", "cerrar", "adios", "terminar", "exit"): "salir",
     }
 
     for palabras, comando in palabras_clave.items():

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -521,12 +521,14 @@ class AdminWindow(ScalingMixin, QWidget):
         if not hasattr(self, "ventana_datos"):
             self.ventana_datos = DatosCuriososWindow(self.usuario)
         self.parent._sincronizar_fuente(self.ventana_datos)
+        self.parent._sincronizar_modo(self.ventana_datos)
         self.ventana_datos.show()
 
     def abrir_gestion_usuarios(self):
         if self.ventana_usuarios is None:
             self.ventana_usuarios = GestionUsuariosWindow(self.gestor_roles)
         self.parent._sincronizar_fuente(self.ventana_usuarios)
+        self.parent._sincronizar_modo(self.ventana_usuarios)
         self.ventana_usuarios.show()
 
     def no_implementado(self):
@@ -800,6 +802,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
                 logout_callback=self.cerrar_sesion,
             )
         self._sincronizar_fuente(self.ventana_usuario)
+        self._sincronizar_modo(self.ventana_usuario)
         self.ventana_usuario.show()
 
     def mostrar_editor_usuario(self):
@@ -808,12 +811,14 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
                 self.usuario, self.gestor_roles
             )
         self._sincronizar_fuente(self.ventana_editor_usuario)
+        self._sincronizar_modo(self.ventana_editor_usuario)
         self.ventana_editor_usuario.show()
 
     def ver_ayuda(self):
         if self.ventana_ayuda is None:
             self.ventana_ayuda = AyudaWindow(self.usuario)
         self._sincronizar_fuente(self.ventana_ayuda)
+        self._sincronizar_modo(self.ventana_ayuda)
         self.ventana_ayuda.show()
 
     def ver_configuracion(self):
@@ -825,6 +830,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
                 aplicar_fuente=self.actualizar_fuente,
             )
         self._sincronizar_fuente(self.ventana_configuracion)
+        self._sincronizar_modo(self.ventana_configuracion)
         self.ventana_configuracion.show()
 
     def ver_admin(self) -> bool:
@@ -859,6 +865,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             )
 
         self._sincronizar_fuente(self.ventana_admin)
+        self._sincronizar_modo(self.ventana_admin)
         self.ventana_admin.show()
         return True
 
@@ -866,6 +873,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         if self.ventana_tree is None:
             self.ventana_tree = TreeWindow()
         self._sincronizar_fuente(self.ventana_tree)
+        self._sincronizar_modo(self.ventana_tree)
         self.ventana_tree.show()
 
     def activate_voice(self):
@@ -981,6 +989,30 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             if hasattr(v, "ventana_datos"):
                 self._sincronizar_fuente(getattr(v, "ventana_datos"))
 
+    def _sincronizar_modo(self, ventana):
+        if ventana is not None:
+            ventana.setStyleSheet(
+                "background-color: #222; color: white;"
+                if self.dark_mode_enabled
+                else ""
+            )
+
+    def _actualizar_modo_ventanas(self):
+        ventanas = [
+            self.ventana_configuracion,
+            self.ventana_usuario,
+            self.ventana_editor_usuario,
+            self.ventana_ayuda,
+            self.ventana_admin,
+            self.ventana_tree,
+        ]
+        for v in ventanas:
+            self._sincronizar_modo(v)
+            if hasattr(v, "ventana_usuarios"):
+                self._sincronizar_modo(getattr(v, "ventana_usuarios"))
+            if hasattr(v, "ventana_datos"):
+                self._sincronizar_modo(getattr(v, "ventana_datos"))
+
     def on_apply_scaling(self, factor: float) -> None:
         fuente = QFont(self.font_family, int(self.base_font_size * factor))
         self.label.setFont(fuente)
@@ -1012,6 +1044,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
             self.button_config.setIcon(QIcon(self.button_config.icon_file))
             self.button_tree.setIcon(QIcon(self.button_tree.icon_file))
 
+        self._actualizar_modo_ventanas()
         self.mensaje_timer.stop()
         self.mensaje_timer.singleShot(5000, lambda: self.label.setText(self.saludo))
 

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -31,6 +31,10 @@ class TestInterpretador(unittest.TestCase):
         resultado = interpretar('abre las funciones de administrador')[0]
         self.assertEqual(resultado, 'modo_admin')
 
+    def test_admin_solo(self):
+        self.assertEqual(interpretar('admin')[0], 'modo_admin')
+        self.assertEqual(interpretar('administrador')[0], 'modo_admin')
+
     def test_arbol(self):
         self.assertEqual(interpretar('tree')[0], 'ver_arbol')
         self.assertEqual(interpretar('árbol')[0], 'ver_arbol')


### PR DESCRIPTION
## Summary
- apply dark mode to all windows
- support `admin` and `administrador` keywords
- remove non-numeric keywords from commands 9 and 10

## Testing
- `pip install num2words`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f4cacfac8332a817ed73b9a18791