### PR TITLE
Implement security question for password resets

### DIFF
--- a/PROMPTY_3.0/data/usuarios.json
+++ b/PROMPTY_3.0/data/usuarios.json
@@ -4,7 +4,9 @@
       "cif": "25010330",
       "nombre": "Erving",
       "rol": "admin",
-      "contrasena": "09f5d690dab14d3e86806267533f6e3439e521d467998f4edf351d5114ebceac"
+      "contrasena": "09f5d690dab14d3e86806267533f6e3439e521d467998f4edf351d5114ebceac",
+      "pregunta": "¿Color favorito del admin?",
+      "respuesta": "ec061fafb777f2943027f2deb3c17961556c386cad45065f343a74aea1177ad0"
     },
     {
       "cif": "25120411",

--- a/PROMPTY_3.0/models/usuario.py
+++ b/PROMPTY_3.0/models/usuario.py
@@ -3,11 +3,13 @@ from utils.helpers import hash_password
 
 
 class Usuario:
-    def __init__(self, cif, nombre, rol, contrasena):
+    def __init__(self, cif, nombre, rol, contrasena, pregunta=None, respuesta=None):
         self.cif = cif
         self.nombre = nombre
         self.rol = rol.lower()
         self.contrasena = contrasena
+        self.pregunta = pregunta
+        self.respuesta = respuesta
         self._permisos = Permisos()
 
     def es_admin(self):
@@ -26,6 +28,12 @@ class Usuario:
     def verificar_contrasena(self, clave_ingresada):
         """Verifica la contraseña comparando hashes."""
         return self.contrasena == hash_password(clave_ingresada)
+
+    def verificar_respuesta(self, respuesta):
+        """Comprueba la respuesta de seguridad, si existe."""
+        if self.respuesta is None:
+            return True
+        return self.respuesta == hash_password(respuesta)
 
     def __str__(self):
         rol_formateado = {

--- a/PROMPTY_3.0/views/login.py
+++ b/PROMPTY_3.0/views/login.py
@@ -53,11 +53,19 @@ class VistaLogin:
         limpiar_pantalla()
         print("🔑 Recuperar contraseña")
         cif = input("CIF: ").strip()
-        nueva = self.gestor_roles.restablecer_contrasena(cif)
+        usuario = self.gestor_roles.obtener_usuario_por_cif(cif)
+        if not usuario:
+            print("❌ CIF no encontrado.")
+            input("Presiona Enter para continuar...")
+            return
+        respuesta = None
+        if usuario.pregunta:
+            respuesta = input(f"{usuario.pregunta}: ").strip()
+        nueva = self.gestor_roles.restablecer_contrasena(cif, respuesta)
         if nueva:
             print(f"Tu nueva contraseña temporal es: {nueva}")
         else:
-            print("❌ CIF no encontrado.")
+            print("❌ Respuesta incorrecta.")
         input("Presiona Enter para continuar...")
 
     def registrar_usuario(self):
@@ -73,7 +81,17 @@ class VistaLogin:
             print("Contraseña no puede estar vacía")
             input("Presiona Enter para continuar...")
             return
-        cif, _ = self.gestor_roles.registrar_usuario(nombre, "usuario", contrasena=clave)
+        pregunta = input("Pregunta de seguridad (opcional): ").strip()
+        respuesta = None
+        if pregunta:
+            respuesta = input("Respuesta: ").strip()
+        cif, _ = self.gestor_roles.registrar_usuario(
+            nombre,
+            "usuario",
+            contrasena=clave,
+            pregunta=pregunta or None,
+            respuesta=respuesta or None,
+        )
         print(f"Registro exitoso. Tu CIF es: {cif}")
         input("Presiona Enter para continuar...")
 

--- a/tests/test_gestor_roles.py
+++ b/tests/test_gestor_roles.py
@@ -16,6 +16,8 @@ def crear_archivo_usuarios(tmp_path):
                 "nombre": "User1",
                 "rol": "admin",
                 "contrasena": helpers.hash_password("pass1"),
+                "pregunta": "Color?",
+                "respuesta": helpers.hash_password("verde"),
             }
         ]
     }
@@ -50,3 +52,18 @@ def test_registrar_usuario(monkeypatch, tmp_path):
     assert contrasena == "pass2"
     nuevo = gr.obtener_usuario_por_cif("2222")
     assert nuevo.nombre == "User2"
+
+
+def test_restablecer_contrasena_ok(tmp_path):
+    ruta = crear_archivo_usuarios(tmp_path)
+    gr = GestorRoles(ruta)
+    nueva = gr.restablecer_contrasena("1111", "verde")
+    assert nueva is not None
+    usuario = gr.obtener_usuario_por_cif("1111")
+    assert usuario.verificar_contrasena(nueva)
+
+
+def test_restablecer_contrasena_falla(tmp_path):
+    ruta = crear_archivo_usuarios(tmp_path)
+    gr = GestorRoles(ruta)
+    assert gr.restablecer_contrasena("1111", "azul") is None


### PR DESCRIPTION
## Summary
- extend `Usuario` model with optional `pregunta` and hashed `respuesta`
- persist these new fields in `gestor_roles`
- require answering the question when resetting password from CLI or GUI
- allow setting a question during user registration
- update default data and add unit tests for this behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686206a381cc8332a1e37de880807581