### PR TITLE
Add security question editing

### DIFF
--- a/PROMPTY_3.0/services/gestor_roles.py
+++ b/PROMPTY_3.0/services/gestor_roles.py
@@ -5,6 +5,9 @@ from models.usuario import Usuario
 from utils.helpers import obtener_logger
 
 
+_SIN_CAMBIO = object()
+
+
 class GestorRoles:
     def __init__(self, ruta_archivo=None):
         if ruta_archivo is None:
@@ -91,21 +94,29 @@ class GestorRoles:
         self.guardar_usuarios()
         return cif, contrasena_plana
 
-    def actualizar_usuario(self, cif, nombre=None, contrasena=None, rol=None, pregunta=None, respuesta=None):
+    def actualizar_usuario(
+        self,
+        cif,
+        nombre=_SIN_CAMBIO,
+        contrasena=_SIN_CAMBIO,
+        rol=_SIN_CAMBIO,
+        pregunta=_SIN_CAMBIO,
+        respuesta=_SIN_CAMBIO,
+    ):
         usuario = self.obtener_usuario_por_cif(cif)
         if not usuario:
             return False
         from utils.helpers import hash_password
 
-        if nombre:
+        if nombre is not _SIN_CAMBIO:
             usuario.nombre = nombre
-        if contrasena:
+        if contrasena is not _SIN_CAMBIO:
             usuario.contrasena = hash_password(contrasena)
-        if pregunta is not None:
+        if pregunta is not _SIN_CAMBIO:
             usuario.pregunta = pregunta
-        if respuesta is not None:
-            usuario.respuesta = hash_password(respuesta)
-        if rol:
+        if respuesta is not _SIN_CAMBIO:
+            usuario.respuesta = hash_password(respuesta) if respuesta is not None else None
+        if rol is not _SIN_CAMBIO and rol:
             usuario.rol = rol.lower()
         self.guardar_usuarios()
         return True

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -261,11 +261,21 @@ class VistaTerminal:
                 nuevo_nombre = input(f"Nuevo nombre [{usuario.nombre}]: ").strip()
                 nueva_clave = input("Nueva contraseña (dejar vacío para no cambiar): ").strip()
                 nuevo_rol = input(f"Nuevo rol [{usuario.rol}] (usuario/colaborador/admin): ").strip().lower()
+                nueva_pregunta = input(
+                    f"Nueva pregunta [{usuario.pregunta or 'ninguna'}] (vacío para no cambiar, '-' para eliminar): "
+                ).strip()
+                nueva_respuesta = None
+                if nueva_pregunta == "-":
+                    nueva_pregunta = None
+                elif nueva_pregunta:
+                    nueva_respuesta = input("Nueva respuesta: ").strip()
                 self.gestor_roles.actualizar_usuario(
                     cif,
                     nombre=nuevo_nombre or None,
                     contrasena=nueva_clave or None,
                     rol=nuevo_rol or None,
+                    pregunta=nueva_pregunta if nueva_pregunta != "" else None,
+                    respuesta=nueva_respuesta,
                 )
                 print("✔ Usuario actualizado.")
             elif opcion == "3":
@@ -290,9 +300,10 @@ class VistaTerminal:
             print("\n✏️ MODIFICAR MIS DATOS")
             print("1. Cambiar nombre")
             print("2. Cambiar contraseña")
-            print("3. Volver")
+            print("3. Cambiar pregunta de seguridad")
+            print("4. Volver")
 
-            opcion = input("Selecciona una opción (1-3): ").strip()
+            opcion = input("Selecciona una opción (1-4): ").strip()
 
             if opcion == "1":
                 nuevo = input("Nuevo nombre: ").strip()
@@ -306,6 +317,21 @@ class VistaTerminal:
                     self.gestor_roles.actualizar_usuario(self.usuario.cif, contrasena=nueva)
                     print("✔ Contraseña actualizada.")
             elif opcion == "3":
+                pregunta = input(
+                    f"Nueva pregunta [{self.usuario.pregunta or 'ninguna'}] (vacío para no cambiar, '-' para eliminar): "
+                ).strip()
+                respuesta = None
+                if pregunta == "-":
+                    pregunta = None
+                elif pregunta:
+                    respuesta = input("Respuesta: ").strip()
+                self.gestor_roles.actualizar_usuario(
+                    self.usuario.cif,
+                    pregunta=pregunta if pregunta != "" else None,
+                    respuesta=respuesta,
+                )
+                print("✔ Pregunta actualizada.")
+            elif opcion == "4":
                 break
             else:
                 print("❌ Opción no válida.")

--- a/tests/test_gestor_roles.py
+++ b/tests/test_gestor_roles.py
@@ -67,3 +67,21 @@ def test_restablecer_contrasena_falla(tmp_path):
     ruta = crear_archivo_usuarios(tmp_path)
     gr = GestorRoles(ruta)
     assert gr.restablecer_contrasena("1111", "azul") is None
+
+
+def test_actualizar_pregunta(tmp_path):
+    ruta = crear_archivo_usuarios(tmp_path)
+    gr = GestorRoles(ruta)
+    gr.actualizar_usuario("1111", pregunta="Mascota?", respuesta="gato")
+    u = gr.obtener_usuario_por_cif("1111")
+    assert u.pregunta == "Mascota?"
+    assert u.verificar_respuesta("gato")
+
+
+def test_eliminar_pregunta(tmp_path):
+    ruta = crear_archivo_usuarios(tmp_path)
+    gr = GestorRoles(ruta)
+    gr.actualizar_usuario("1111", pregunta=None, respuesta=None)
+    u = gr.obtener_usuario_por_cif("1111")
+    assert u.pregunta is None
+    assert u.respuesta is None


### PR DESCRIPTION
## Summary
- let admins edit users' security questions in terminal UI
- allow users to change their own security question
- support removing or updating questions in GestorRoles
- test question update and deletion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620c2c2c788332bec88ed84054309e