### PR TITLE
Add AI service and HTTP API for PROMPTY

### DIFF
--- a/PROMPTY_3.0/api/__init__.py
+++ b/PROMPTY_3.0/api/__init__.py
@@ -1,0 +1,1 @@
+"""Punto de entrada para exponer PROMPTY como servicio HTTP."""

--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -1,0 +1,64 @@
+"""API REST ligera para consumir las capacidades inteligentes de PROMPTY."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel, Field
+
+from services.ai_client import ServicioIA
+
+app = FastAPI(
+    title="PROMPTY AI Service",
+    description=(
+        "Servicio HTTP para consultar la capa inteligente de PROMPTY. "
+        "Puede reutilizarse desde MyPlanU u otros clientes."
+    ),
+    version="1.0.0",
+)
+
+servicio_ia = ServicioIA()
+
+
+class MensajeHistorial(BaseModel):
+    rol: str = Field(..., pattern="^(usuario|asistente|user|assistant)$")
+    contenido: str = Field(..., min_length=1)
+
+
+class ChatRequest(BaseModel):
+    mensaje: str = Field(..., min_length=1)
+    historial: Optional[List[MensajeHistorial]] = None
+
+
+class ChatResponse(BaseModel):
+    respuesta: str
+    exito: bool
+
+
+@app.get("/health")
+async def healthcheck() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/api/chat", response_model=ChatResponse)
+async def chat(request: ChatRequest) -> ChatResponse:
+    try:
+        respuesta, exito = await run_in_threadpool(
+            servicio_ia.consultar, request.mensaje, [
+                {"rol": h.rol, "contenido": h.contenido} for h in request.historial or []
+            ]
+        )
+    except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return ChatResponse(respuesta=respuesta, exito=exito)
+
+
+@app.get("/")
+async def root() -> dict:
+    return {
+        "mensaje": "PROMPTY API lista",
+        "endpoints": ["GET /health", "POST /api/chat"],
+    }

--- a/PROMPTY_3.0/services/ai_client.py
+++ b/PROMPTY_3.0/services/ai_client.py
@@ -1,0 +1,172 @@
+"""Cliente para conectarse con modelos de IA externos (Hugging Face por defecto)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+
+_SYSTEM_PROMPT = (
+    "Eres PROMPTY, un asistente de escritorio en español. "
+    "Tu misión es responder con pasos claros y concretos en menos de 200 palabras. "
+    "Puedes razonar y proponer acciones pero nunca inventes datos ni enlaces que no existan."
+)
+
+
+@dataclass
+class IAConfig:
+    """Configuración necesaria para conectarse al proveedor de IA."""
+
+    api_token: Optional[str] = None
+    model_id: str = "mistralai/Mistral-7B-Instruct-v0.3"
+    base_url: Optional[str] = None
+    timeout: float = 45.0
+    max_new_tokens: int = 320
+    temperature: float = 0.4
+
+    @property
+    def endpoint(self) -> str:
+        if self.base_url:
+            return self.base_url.rstrip("/")
+        return f"https://api-inference.huggingface.co/models/{self.model_id}"
+
+    @classmethod
+    def from_env(cls) -> "IAConfig":
+        token = (
+            os.getenv("PROMPTY_IA_TOKEN")
+            or os.getenv("HUGGING_FACE_API_TOKEN")
+            or os.getenv("HF_API_TOKEN")
+        )
+        model = os.getenv("PROMPTY_IA_MODEL") or cls.model_id
+        base_url = os.getenv("PROMPTY_IA_BASE_URL")
+        timeout = float(os.getenv("PROMPTY_IA_TIMEOUT", cls.timeout))
+        max_new_tokens = int(os.getenv("PROMPTY_IA_MAX_TOKENS", cls.max_new_tokens))
+        temperature = float(os.getenv("PROMPTY_IA_TEMPERATURE", cls.temperature))
+        return cls(
+            api_token=token,
+            model_id=model,
+            base_url=base_url,
+            timeout=timeout,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+        )
+
+
+class ServicioIA:
+    """Encapsula las llamadas HTTP hacia el proveedor de IA."""
+
+    def __init__(self, config: Optional[IAConfig] = None, client: Optional[httpx.Client] = None):
+        self.config = config or IAConfig.from_env()
+        self._client = client
+        self._client_lock = Lock()
+
+    def _get_client(self) -> httpx.Client:
+        with self._client_lock:
+            if self._client is None:
+                self._client = httpx.Client(timeout=self.config.timeout)
+            return self._client
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.config.api_token:
+            headers["Authorization"] = f"Bearer {self.config.api_token}"
+        return headers
+
+    def _build_prompt(self, mensaje: str, historial: Optional[List[Dict[str, str]]]) -> str:
+        bloques = [_SYSTEM_PROMPT, "\nHistorial de la conversación:\n"]
+        if historial:
+            for turno in historial:
+                rol = turno.get("rol") or turno.get("role") or "usuario"
+                contenido = turno.get("contenido") or turno.get("content") or ""
+                prefijo = "Usuario" if rol.startswith("u") else "PROMPTY"
+                bloques.append(f"{prefijo}: {contenido}\n")
+        bloques.append(f"Usuario: {mensaje}\nPROMPTY:")
+        return "".join(bloques)
+
+    def _build_payload(self, mensaje: str, historial: Optional[List[Dict[str, str]]]) -> Dict[str, Any]:
+        prompt = self._build_prompt(mensaje, historial)
+        return {
+            "inputs": prompt,
+            "parameters": {
+                "max_new_tokens": self.config.max_new_tokens,
+                "temperature": self.config.temperature,
+                "return_full_text": False,
+            },
+        }
+
+    def _extraer_texto(self, data: Any) -> Optional[str]:
+        if isinstance(data, list) and data:
+            candidato = data[0]
+            if isinstance(candidato, dict):
+                if "generated_text" in candidato:
+                    return candidato["generated_text"].strip()
+                if "error" in candidato:
+                    return f"❌ {candidato['error']}"
+        if isinstance(data, dict):
+            if "generated_text" in data:
+                return data["generated_text"].strip()
+            if "error" in data:
+                return f"❌ {data['error']}"
+        return None
+
+    def consultar(
+        self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
+    ) -> tuple[str, bool]:
+        mensaje = (mensaje or "").strip()
+        if not mensaje:
+            return "❌ No recibí ningún mensaje para enviar a la IA.", False
+
+        if not self.config.api_token and not self.config.base_url:
+            return (
+                "⚠️ Para habilitar el modo inteligente define la variable de entorno "
+                "'HUGGING_FACE_API_TOKEN' (puedes obtener un token gratuito en huggingface.co).",
+                False,
+            )
+
+        payload = self._build_payload(mensaje, historial)
+        try:
+            respuesta = self._get_client().post(
+                self.config.endpoint,
+                headers=self._headers(),
+                json=payload,
+            )
+            respuesta.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            cuerpo = exc.response.json() if exc.response.content else {}
+            detalle = cuerpo.get("error") if isinstance(cuerpo, dict) else str(cuerpo)
+            return f"❌ Error al consultar la IA: {detalle or exc}", False
+        except httpx.RequestError as exc:
+            return f"❌ No pude comunicarme con la IA: {exc}", False
+
+        try:
+            data = respuesta.json()
+        except ValueError:
+            return "❌ La IA devolvió una respuesta inválida.", False
+
+        texto = self._extraer_texto(data)
+        if not texto:
+            return "⚠️ La IA no envió contenido útil.", False
+
+        return texto.strip(), True
+
+
+class AsistenteIA:
+    """Gestiona el historial de conversación y delega la consulta al servicio."""
+
+    def __init__(self, servicio: Optional[ServicioIA] = None):
+        self.servicio = servicio or ServicioIA()
+        self.historial: List[Dict[str, str]] = []
+
+    def reiniciar_historial(self) -> None:
+        self.historial.clear()
+
+    def responder(self, mensaje: str) -> str:
+        texto, exito = self.servicio.consultar(mensaje, self.historial)
+        if exito:
+            self.historial.append({"rol": "usuario", "contenido": mensaje.strip()})
+            self.historial.append({"rol": "asistente", "contenido": texto})
+        return texto

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -34,6 +34,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 from services.asistente_voz import ServicioVoz
+from services.ai_client import AsistenteIA
 from services.gestor_comandos import GestorComandos
 from services.gestor_roles import GestorRoles
 from services.autenticacion import ServicioAutenticacion
@@ -712,6 +713,7 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         self.auth_service = ServicioAutenticacion(self.gestor_roles)
         self.servicio_voz = ServicioVoz(usuario, verificar_admin_callback=self.gestor_roles.autenticar)
         self.gestor_comandos = GestorComandos(usuario)
+        self.asistente_ia = AsistenteIA()
         self.setWindowTitle("PROMTY - Asistente de Voz")
         self.setGeometry(100, 100, 400, 600)
         self.base_width = 400
@@ -985,6 +987,8 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         elif comando == "ver_arbol":
             self.ver_arbol_programa()
             respuesta = "Mostrando estructura del proyecto..."
+        elif comando == "comando_no_reconocido":
+            respuesta = self.asistente_ia.responder(texto)
         else:
             # Llamadas que requieren interacción del usuario
             interactivos = {

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from colorama import Fore, Style
 from services.asistente_voz import ServicioVoz
+from services.ai_client import AsistenteIA
 from services.gestor_comandos import GestorComandos
 from services.gestor_roles import GestorRoles
 from services.autenticacion import ServicioAutenticacion
@@ -18,6 +19,7 @@ class VistaTerminal:
         self.auth_service = ServicioAutenticacion(self.gestor_roles)
         self.asistente_voz = ServicioVoz(usuario, verificar_admin_callback=self.gestor_roles.autenticar)
         self.gestor_comandos = GestorComandos(usuario)
+        self.asistente_ia = AsistenteIA()
         self.modo_respuesta = "texto"
 
     def iniciar(self):
@@ -30,7 +32,7 @@ class VistaTerminal:
             self.asistente_voz.hablar(quitar_colores("Hola. Estoy listo para ayudarte."))
 
         while True:
-            comando, argumentos = self.obtener_instruccion()
+            comando, argumentos, texto_original = self.obtener_instruccion()
 
             if comando == "modo_admin":
                 self.menu_admin()
@@ -60,13 +62,10 @@ class VistaTerminal:
                 continue
 
             if comando == "comando_no_reconocido":
-                mensaje = (
-                    "❌ Comando no reconocido. "
-                    "Puedes consultar las opciones disponibles escribiendo 'ayuda'."
-                )
-                print(mensaje)
+                respuesta = self.asistente_ia.responder(texto_original)
+                print(respuesta)
                 if self.modo_respuesta in ["voz", "ambos"]:
-                    self.asistente_voz.hablar(quitar_colores(mensaje))
+                    self.asistente_voz.hablar(quitar_colores(respuesta))
                 continue
 
             # Comandos que requieren entrada
@@ -138,7 +137,8 @@ class VistaTerminal:
         else:
             entrada = ""
 
-        return interpretar(entrada)
+        comando, argumentos = interpretar(entrada)
+        return comando, argumentos, entrada
 
     def salir_programa(self):
         mensaje = "👋 Hasta luego. Fue un placer ayudarte."

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - Acceso a datos curiosos integrados
 - Gestión de usuarios con permisos (usuario, colaborador, administrador)
 - Ventanas independientes para ayuda, configuración de voz e información del usuario
+- Nuevo modo "inteligente" conectado a modelos de IA gratuitos (Hugging Face Inference API)
+- Servidor HTTP opcional para reutilizar PROMPTY como servicio en otras apps
 
 ---
 
@@ -52,6 +54,65 @@ uv run .\PROMPTY_3.0\main.py
 ```
 
 > ⚠️ Asegúrate de usar Python 3.10 o superior. Python 3.13 es recomendado para compatibilidad total.
+
+---
+
+## 🧠 Activar el modo inteligente (IA gratuita)
+
+PROMPTY puede conectarse a cualquier modelo disponible en la [Hugging Face Inference API](https://huggingface.co/inference-api) —incluidas alternativas gratuitas como **Mistral 7B Instruct**—, lo que añade razonamiento natural cuando se ingresan comandos no soportados.
+
+1. Crea una cuenta en Hugging Face y genera un token personal (es gratuito y ofrece suficientes tokens para pruebas).
+2. Define la variable de entorno antes de iniciar PROMPTY:
+
+```bash
+export HUGGING_FACE_API_TOKEN="hf_xxx"
+# Opcional: cambia de modelo si lo deseas
+export PROMPTY_IA_MODEL="mistralai/Mistral-7B-Instruct-v0.3"
+```
+
+3. Ejecuta PROMPTY normalmente (por GUI o terminal). Cuando escribas o digas algo fuera de los comandos predefinidos, la IA responderá usando el modelo remoto.
+
+Variables extra disponibles:
+
+| Variable | Descripción |
+| --- | --- |
+| `PROMPTY_IA_BASE_URL` | Endpoint personalizado (por ejemplo, si alojas tu propio modelo o llamas a Gemini vía proxy compatible). |
+| `PROMPTY_IA_TIMEOUT` | Tiempo máximo de espera en segundos (por defecto 45). |
+| `PROMPTY_IA_MAX_TOKENS` | Límite de tokens generados por respuesta (320 por defecto). |
+| `PROMPTY_IA_TEMPERATURE` | Control de creatividad del modelo. |
+
+---
+
+## 🔌 Convertir a servicio/API para MyPlanU
+
+La carpeta `PROMPTY_3.0/api` expone un servidor FastAPI listo para integrarse desde MyPlanU (C# MAUI + SQLite) u otros clientes.
+
+```bash
+# Requiere haber ejecutado `uv sync` previamente
+uv run uvicorn PROMPTY_3_0.api.server:app --reload --port 8000
+```
+
+Endpoints principales:
+
+| Método | Ruta | Descripción |
+| --- | --- | --- |
+| `GET /health` | Verifica que el servicio esté activo. |
+| `POST /api/chat` | Envía un mensaje y recibe la respuesta de la IA. |
+
+Ejemplo de consumo desde cualquier cliente HTTP:
+
+```bash
+curl -X POST http://localhost:8000/api/chat \
+     -H "Content-Type: application/json" \
+     -d '{
+            "mensaje": "Genera un resumen del plan semanal",
+            "historial": [
+                {"rol": "usuario", "contenido": "Necesito organizar tareas"}
+            ]
+        }'
+```
+
+La respuesta JSON contiene `respuesta` (texto generado) y `exito` (bandera booleana). Desde MyPlanU basta con realizar esta petición HTTP para reutilizar las capacidades de PROMPTY como microservicio.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "colorama>=0.4.6",
+    "fastapi>=0.111.0",
+    "httpx>=0.27.0",
     "pathspec>=0.12.1",
     "pyaudio>=0.2.14",
     "pyqt6>=6.9.1",
@@ -11,4 +13,5 @@ dependencies = [
     "pyttsx3>=2.98",
     "speechrecognition>=3.14.3",
     "num2words>=0.5.13",
+    "uvicorn>=0.30.0",
 ]

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -1,0 +1,44 @@
+"""Tests unitarios para la capa de integración con IA."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'PROMPTY_3.0'))
+
+from services.ai_client import IAConfig, ServicioIA
+
+
+def test_config_from_env(monkeypatch):
+    monkeypatch.setenv("HUGGING_FACE_API_TOKEN", "abc123")
+    monkeypatch.setenv("PROMPTY_IA_MODEL", "meta-llama/Llama-3.1-8B-Instruct")
+    monkeypatch.setenv("PROMPTY_IA_BASE_URL", "https://demo.test/model")
+    monkeypatch.setenv("PROMPTY_IA_TIMEOUT", "12.5")
+    monkeypatch.setenv("PROMPTY_IA_MAX_TOKENS", "128")
+    monkeypatch.setenv("PROMPTY_IA_TEMPERATURE", "0.75")
+
+    config = IAConfig.from_env()
+
+    assert config.api_token == "abc123"
+    assert config.model_id == "meta-llama/Llama-3.1-8B-Instruct"
+    assert config.endpoint == "https://demo.test/model"
+    assert config.timeout == 12.5
+    assert config.max_new_tokens == 128
+    assert config.temperature == 0.75
+
+
+def test_build_payload_includes_historial():
+    config = IAConfig(api_token="token", model_id="demo-model")
+    servicio = ServicioIA(config=config, client=None)
+
+    historial = [
+        {"rol": "usuario", "contenido": "Hola"},
+        {"rol": "asistente", "contenido": "¿En qué te ayudo?"},
+    ]
+
+    payload = servicio._build_payload("Necesito ideas", historial)
+
+    assert "Necesito ideas" in payload["inputs"]
+    assert "Usuario: Hola" in payload["inputs"]
+    assert "PROMPTY: ¿En qué te ayudo?" in payload["inputs"]
+    assert payload["parameters"]["max_new_tokens"] == config.max_new_tokens
+    assert payload["parameters"]["temperature"] == config.temperature


### PR DESCRIPTION
## Summary
- add a reusable AI client that connects to Hugging Face Inference API (or any compatible endpoint) and integrate it into the terminal and GUI views so unrecognized comandos are answered with reasoning responses
- document how to enable the free IA mode, expose PROMPTY as a FastAPI service for MyPlanU, and add the required dependencies plus unit tests for the new client
- expose a reusable HTTP API (`PROMPTY_3.0/api/server.py`) so external apps can consume PROMPTY as a service

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de57fc2188332a1891aa81ee67c03)