### PR TITLE
Extract AI integration into dedicated module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__/
 *.py[cod]
 *.so
 .env
+config_local.json
 venv/

--- a/PROMPTY_3.0/ai/__init__.py
+++ b/PROMPTY_3.0/ai/__init__.py
@@ -1,0 +1,12 @@
+"""Interfaces públicas para la integración de IA en PROMPTY."""
+from .assistant import AsistenteIA
+from .config import CONFIG_LOCAL_PATH, DEFAULT_BASE_URL, IAConfig
+from .service import ServicioIA
+
+__all__ = [
+    "AsistenteIA",
+    "CONFIG_LOCAL_PATH",
+    "DEFAULT_BASE_URL",
+    "IAConfig",
+    "ServicioIA",
+]

--- a/PROMPTY_3.0/ai/assistant.py
+++ b/PROMPTY_3.0/ai/assistant.py
@@ -1,0 +1,24 @@
+"""Gestiona el historial de conversación y delega la consulta al servicio de IA."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .service import ServicioIA
+
+
+class AsistenteIA:
+    """Gestiona el historial de conversación y delega la consulta al servicio."""
+
+    def __init__(self, servicio: Optional[ServicioIA] = None):
+        self.servicio = servicio or ServicioIA()
+        self.historial: List[Dict[str, str]] = []
+
+    def reiniciar_historial(self) -> None:
+        self.historial.clear()
+
+    def responder(self, mensaje: str) -> str:
+        texto, exito = self.servicio.consultar(mensaje, self.historial)
+        if exito:
+            self.historial.append({"rol": "usuario", "contenido": mensaje.strip()})
+            self.historial.append({"rol": "asistente", "contenido": texto})
+        return texto

--- a/PROMPTY_3.0/ai/config.py
+++ b/PROMPTY_3.0/ai/config.py
@@ -1,0 +1,76 @@
+"""Carga y modela la configuración necesaria para usar la IA remota."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+DEFAULT_BASE_URL = "https://router.huggingface.co"
+CONFIG_LOCAL_PATH = Path(__file__).resolve().parent.parent / "config_local.json"
+
+
+@dataclass
+class IAConfig:
+    """Configuración necesaria para conectarse al proveedor de IA."""
+
+    api_token: Optional[str] = None
+    model_id: str = "mistralai/Mistral-7B-Instruct-v0.3"
+    base_url: Optional[str] = DEFAULT_BASE_URL
+    timeout: float = 45.0
+    max_new_tokens: int = 320
+    temperature: float = 0.4
+
+    @property
+    def endpoint(self) -> str:
+        base = (self.base_url or DEFAULT_BASE_URL).rstrip("/")
+        if base.endswith("/v1/chat"):
+            return f"{base}/completions"
+        if base.endswith("/v1"):
+            return f"{base}/chat/completions"
+        return f"{base}/v1/chat/completions"
+
+    @classmethod
+    def _load_local_config(cls) -> Dict[str, Any]:
+        if not CONFIG_LOCAL_PATH.exists():
+            return {}
+        try:
+            with CONFIG_LOCAL_PATH.open("r", encoding="utf-8") as handler:
+                data = json.load(handler)
+            if isinstance(data, dict):
+                return data
+        except (OSError, ValueError):
+            pass
+        return {}
+
+    @classmethod
+    def from_env(cls) -> "IAConfig":
+        local_config = cls._load_local_config()
+        token = local_config.get("api_token") if isinstance(local_config, dict) else None
+        model = local_config.get("model_id") if isinstance(local_config, dict) else None
+        base_url = local_config.get("base_url") if isinstance(local_config, dict) else None
+        timeout = local_config.get("timeout") if isinstance(local_config, dict) else None
+        max_new_tokens = (
+            local_config.get("max_new_tokens") if isinstance(local_config, dict) else None
+        )
+        temperature = local_config.get("temperature") if isinstance(local_config, dict) else None
+
+        token = token or (
+            os.getenv("PROMPTY_IA_TOKEN")
+            or os.getenv("HUGGING_FACE_API_TOKEN")
+            or os.getenv("HF_API_TOKEN")
+        )
+        model = model or os.getenv("PROMPTY_IA_MODEL") or cls.model_id
+        base_url = base_url or os.getenv("PROMPTY_IA_BASE_URL") or DEFAULT_BASE_URL
+        timeout = float(timeout or os.getenv("PROMPTY_IA_TIMEOUT", cls.timeout))
+        max_new_tokens = int(max_new_tokens or os.getenv("PROMPTY_IA_MAX_TOKENS", cls.max_new_tokens))
+        temperature = float(temperature or os.getenv("PROMPTY_IA_TEMPERATURE", cls.temperature))
+        return cls(
+            api_token=token,
+            model_id=model,
+            base_url=base_url,
+            timeout=timeout,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+        )

--- a/PROMPTY_3.0/ai/service.py
+++ b/PROMPTY_3.0/ai/service.py
@@ -1,59 +1,18 @@
-"""Cliente para conectarse con modelos de IA externos (Hugging Face por defecto)."""
-
+"""Cliente HTTP que delega llamadas al proveedor de IA."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-import os
 from threading import Lock
 from typing import Any, Dict, List, Optional
 
 import httpx
 
+from .config import CONFIG_LOCAL_PATH, IAConfig
 
 _SYSTEM_PROMPT = (
     "Eres PROMPTY, un asistente de escritorio en español. "
     "Tu misión es responder con pasos claros y concretos en menos de 200 palabras. "
     "Puedes razonar y proponer acciones pero nunca inventes datos ni enlaces que no existan."
 )
-
-
-@dataclass
-class IAConfig:
-    """Configuración necesaria para conectarse al proveedor de IA."""
-
-    api_token: Optional[str] = None
-    model_id: str = "mistralai/Mistral-7B-Instruct-v0.3"
-    base_url: Optional[str] = None
-    timeout: float = 45.0
-    max_new_tokens: int = 320
-    temperature: float = 0.4
-
-    @property
-    def endpoint(self) -> str:
-        if self.base_url:
-            return self.base_url.rstrip("/")
-        return f"https://router.huggingface.co/hf-inference/models/{self.model_id}"
-
-    @classmethod
-    def from_env(cls) -> "IAConfig":
-        token = (
-            os.getenv("PROMPTY_IA_TOKEN")
-            or os.getenv("HUGGING_FACE_API_TOKEN")
-            or os.getenv("HF_API_TOKEN")
-        )
-        model = os.getenv("PROMPTY_IA_MODEL") or cls.model_id
-        base_url = os.getenv("PROMPTY_IA_BASE_URL")
-        timeout = float(os.getenv("PROMPTY_IA_TIMEOUT", cls.timeout))
-        max_new_tokens = int(os.getenv("PROMPTY_IA_MAX_TOKENS", cls.max_new_tokens))
-        temperature = float(os.getenv("PROMPTY_IA_TEMPERATURE", cls.temperature))
-        return cls(
-            api_token=token,
-            model_id=model,
-            base_url=base_url,
-            timeout=timeout,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
-        )
 
 
 class ServicioIA:
@@ -76,29 +35,42 @@ class ServicioIA:
             headers["Authorization"] = f"Bearer {self.config.api_token}"
         return headers
 
-    def _build_prompt(self, mensaje: str, historial: Optional[List[Dict[str, str]]]) -> str:
-        bloques = [_SYSTEM_PROMPT, "\nHistorial de la conversación:\n"]
+    def _build_messages(self, mensaje: str, historial: Optional[List[Dict[str, str]]]) -> List[Dict[str, str]]:
+        mensajes: List[Dict[str, str]] = [
+            {"role": "system", "content": _SYSTEM_PROMPT}
+        ]
         if historial:
             for turno in historial:
-                rol = turno.get("rol") or turno.get("role") or "usuario"
+                rol = (turno.get("rol") or turno.get("role") or "usuario").lower()
                 contenido = turno.get("contenido") or turno.get("content") or ""
-                prefijo = "Usuario" if rol.startswith("u") else "PROMPTY"
-                bloques.append(f"{prefijo}: {contenido}\n")
-        bloques.append(f"Usuario: {mensaje}\nPROMPTY:")
-        return "".join(bloques)
+                role = "assistant" if rol.startswith("a") else "user"
+                mensajes.append({"role": role, "content": contenido})
+        mensajes.append({"role": "user", "content": mensaje})
+        return mensajes
 
     def _build_payload(self, mensaje: str, historial: Optional[List[Dict[str, str]]]) -> Dict[str, Any]:
-        prompt = self._build_prompt(mensaje, historial)
         return {
-            "inputs": prompt,
-            "parameters": {
-                "max_new_tokens": self.config.max_new_tokens,
-                "temperature": self.config.temperature,
-                "return_full_text": False,
-            },
+            "model": self.config.model_id,
+            "messages": self._build_messages(mensaje, historial),
+            "temperature": self.config.temperature,
+            "max_tokens": self.config.max_new_tokens,
         }
 
     def _extraer_texto(self, data: Any) -> Optional[str]:
+        if isinstance(data, dict):
+            if "choices" in data and isinstance(data["choices"], list):
+                for choice in data["choices"]:
+                    mensaje = choice.get("message") if isinstance(choice, dict) else None
+                    if isinstance(mensaje, dict) and "content" in mensaje:
+                        return str(mensaje.get("content", "")).strip()
+                    delta = choice.get("delta") if isinstance(choice, dict) else None
+                    if isinstance(delta, dict) and "content" in delta:
+                        return str(delta.get("content", "")).strip()
+            if "generated_text" in data:
+                return str(data["generated_text"]).strip()
+            if "error" in data:
+                return f"❌ {data['error']}"
+
         if isinstance(data, list) and data:
             candidato = data[0]
             if isinstance(candidato, dict):
@@ -106,11 +78,6 @@ class ServicioIA:
                     return candidato["generated_text"].strip()
                 if "error" in candidato:
                     return f"❌ {candidato['error']}"
-        if isinstance(data, dict):
-            if "generated_text" in data:
-                return data["generated_text"].strip()
-            if "error" in data:
-                return f"❌ {data['error']}"
         return None
 
     def consultar(
@@ -120,9 +87,10 @@ class ServicioIA:
         if not mensaje:
             return "❌ No recibí ningún mensaje para enviar a la IA.", False
 
-        if not self.config.api_token and not self.config.base_url:
+        if not self.config.api_token:
             return (
-                "⚠️ Para habilitar el modo inteligente define la variable de entorno "
+                "⚠️ Para habilitar el modo inteligente coloca tu token en 'config_local.json' "
+                f"({CONFIG_LOCAL_PATH}) o define la variable de entorno "
                 "'HUGGING_FACE_API_TOKEN' (puedes obtener un token gratuito en huggingface.co).",
                 False,
             )
@@ -152,21 +120,3 @@ class ServicioIA:
             return "⚠️ La IA no envió contenido útil.", False
 
         return texto.strip(), True
-
-
-class AsistenteIA:
-    """Gestiona el historial de conversación y delega la consulta al servicio."""
-
-    def __init__(self, servicio: Optional[ServicioIA] = None):
-        self.servicio = servicio or ServicioIA()
-        self.historial: List[Dict[str, str]] = []
-
-    def reiniciar_historial(self) -> None:
-        self.historial.clear()
-
-    def responder(self, mensaje: str) -> str:
-        texto, exito = self.servicio.consultar(mensaje, self.historial)
-        if exito:
-            self.historial.append({"rol": "usuario", "contenido": mensaje.strip()})
-            self.historial.append({"rol": "asistente", "contenido": texto})
-        return texto

--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
-from services.ai_client import ServicioIA
+from ai import ServicioIA
 
 app = FastAPI(
     title="PROMPTY AI Service",

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -34,7 +34,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 from services.asistente_voz import ServicioVoz
-from services.ai_client import AsistenteIA
+from ai import AsistenteIA
 from services.gestor_comandos import GestorComandos
 from services.gestor_roles import GestorRoles
 from services.autenticacion import ServicioAutenticacion

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from colorama import Fore, Style
 from services.asistente_voz import ServicioVoz
-from services.ai_client import AsistenteIA
+from ai import AsistenteIA
 from services.gestor_comandos import GestorComandos
 from services.gestor_roles import GestorRoles
 from services.autenticacion import ServicioAutenticacion

--- a/README.md
+++ b/README.md
@@ -60,10 +60,21 @@ uv run .\PROMPTY_3.0\main.py
 ## 🧠 Activar el modo inteligente (IA gratuita)
 
 PROMPTY puede conectarse a cualquier modelo disponible en la [Hugging Face Inference API](https://huggingface.co/inference-api) —incluidas alternativas gratuitas como **Mistral 7B Instruct**—, lo que añade razonamiento natural cuando se ingresan comandos no soportados.
-Por defecto se usa el router público (`https://router.huggingface.co/hf-inference/models/...`).
+Desde la versión 3.0 usamos el endpoint OpenAI-style `https://router.huggingface.co/v1/chat/completions`, compatible con los *Inference Providers* actuales.
 
-1. Crea una cuenta en Hugging Face y genera un token personal (es gratuito y ofrece suficientes tokens para pruebas).
-2. Define la variable de entorno antes de iniciar PROMPTY:
+1. Crea un archivo `PROMPTY_3.0/config_local.json` (excluido del repositorio) con tu token y modelo:
+
+```json
+{
+  "api_token": "hf_xxx",
+ "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+  "base_url": "https://router.huggingface.co"
+}
+```
+
+> La integración de IA vive ahora en `PROMPTY_3.0/ai/` (separada de `services/`) para facilitar su mantenimiento.
+
+2. Si prefieres variables de entorno (o como *fallback* si el archivo no existe), puedes definirlas antes de iniciar PROMPTY:
 
 ```bash
 export HUGGING_FACE_API_TOKEN="hf_xxx"

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -5,13 +5,30 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'PROMPTY_3.0'))
 
-from services.ai_client import IAConfig, ServicioIA
+from ai import IAConfig, ServicioIA
 
 
-def test_config_from_env(monkeypatch):
+def test_config_prefers_local_file(tmp_path, monkeypatch):
+    dummy_config = tmp_path / "config_local.json"
+    dummy_config.write_text(
+        '{"api_token": "local_token", "model_id": "local-model", "base_url": "https://custom"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("ai.config.CONFIG_LOCAL_PATH", dummy_config)
+    monkeypatch.delenv("HUGGING_FACE_API_TOKEN", raising=False)
+
+    config = IAConfig.from_env()
+
+    assert config.api_token == "local_token"
+    assert config.model_id == "local-model"
+    assert config.endpoint == "https://custom/v1/chat/completions"
+
+
+def test_config_falls_back_to_env(monkeypatch):
+    monkeypatch.setattr("ai.config.CONFIG_LOCAL_PATH", Path("/tmp/not_found.json"))
     monkeypatch.setenv("HUGGING_FACE_API_TOKEN", "abc123")
     monkeypatch.setenv("PROMPTY_IA_MODEL", "meta-llama/Llama-3.1-8B-Instruct")
-    monkeypatch.setenv("PROMPTY_IA_BASE_URL", "https://demo.test/model")
+    monkeypatch.setenv("PROMPTY_IA_BASE_URL", "https://demo.test/api")
     monkeypatch.setenv("PROMPTY_IA_TIMEOUT", "12.5")
     monkeypatch.setenv("PROMPTY_IA_MAX_TOKENS", "128")
     monkeypatch.setenv("PROMPTY_IA_TEMPERATURE", "0.75")
@@ -20,16 +37,10 @@ def test_config_from_env(monkeypatch):
 
     assert config.api_token == "abc123"
     assert config.model_id == "meta-llama/Llama-3.1-8B-Instruct"
-    assert config.endpoint == "https://demo.test/model"
+    assert config.endpoint == "https://demo.test/api/v1/chat/completions"
     assert config.timeout == 12.5
     assert config.max_new_tokens == 128
     assert config.temperature == 0.75
-
-
-def test_default_endpoint_uses_router_domain():
-    config = IAConfig()
-
-    assert config.endpoint == "https://router.huggingface.co/hf-inference/models/mistralai/Mistral-7B-Instruct-v0.3"
 
 
 def test_build_payload_includes_historial():
@@ -43,8 +54,8 @@ def test_build_payload_includes_historial():
 
     payload = servicio._build_payload("Necesito ideas", historial)
 
-    assert "Necesito ideas" in payload["inputs"]
-    assert "Usuario: Hola" in payload["inputs"]
-    assert "PROMPTY: ¿En qué te ayudo?" in payload["inputs"]
-    assert payload["parameters"]["max_new_tokens"] == config.max_new_tokens
-    assert payload["parameters"]["temperature"] == config.temperature
+    assert payload["model"] == "demo-model"
+    assert payload["temperature"] == config.temperature
+    assert payload["max_tokens"] == config.max_new_tokens
+    assert payload["messages"][0]["role"] == "system"
+    assert payload["messages"][-1]["content"] == "Necesito ideas"


### PR DESCRIPTION
## Summary
- move the IA configuration, service, and assistant classes into a dedicated `PROMPTY_3.0/ai/` package
- keep local-config-first token loading, update entry points to the new module, and document the new location in the README
- refresh the AI unit tests to cover the OpenAI-style payload and config precedence

## Testing
- `python -m pytest tests/test_ai_client.py` *(fails: missing httpx dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923aa1a90048332ae4b3ff139941a2c)