### PR TITLE
Add AI confirmation for detected commands

### DIFF
--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -2,15 +2,18 @@ import re
 
 
 def interpretar(texto):
-    """Devuelve (comando, argumentos) a partir de una cadena.
+    """Devuelve (comando, argumentos, palabra_clave) a partir de una cadena.
 
-    Si no se reconoce la orden, el comando será "comando_no_reconocido"
-    y los argumentos serán None.
+    Si no se reconoce la orden, el comando será "comando_no_reconocido",
+    los argumentos serán None y la palabra clave será None.
     """
     texto = texto.lower().strip()
     texto = texto.replace("en el", "en")  # Normaliza "buscar en el navegador" → "buscar en navegador"
 
     texto_simple = re.sub(r"[!.,?]", "", texto).strip()
+
+    def resultado(comando, palabra_clave=None):
+        return comando, None, palabra_clave
     saludos = [
         "hola",
         "hola prompty",
@@ -21,21 +24,21 @@ def interpretar(texto):
         "como estas",
     ]
     if texto_simple in saludos:
-        return "saludo", None
+        return resultado("saludo", texto_simple)
 
     if "administrador" in texto and "funciones" in texto:
-        return "modo_admin", None
+        return resultado("modo_admin", "funciones de administrador")
 
     if "buscar" in texto:
         if "youtube" in texto:
-            return "buscar_en_youtube", None
+            return resultado("buscar_en_youtube", "youtube")
         elif "google" in texto or "navegador" in texto:
             # Si el usuario especifica google o navegador, se asume que
             # desea realizar la búsqueda directamente en ese destino.
-            return "buscar_en_navegador", None
+            return resultado("buscar_en_navegador", "navegador")
         else:
             # El usuario dijo "buscar" pero no indicó destino; se pregunta dónde.
-            return "buscar_general", None
+            return resultado("buscar_general", "buscar")
 
     if any(p in texto for p in [
         "musica",
@@ -45,19 +48,19 @@ def interpretar(texto):
         "canción",
         "canciones",
     ]):
-        return "reproducir_musica", None
+        return resultado("reproducir_musica", "musica")
 
     if "dia" in texto_simple or "hoy" in texto_simple:
-        return "dia_fecha", None
+        return resultado("dia_fecha", "dia")
 
     if re.search(r"\bfecha\b", texto) and re.search(r"\bhora\b", texto):
-        return "fecha_hora", None
+        return resultado("fecha_hora", "fecha y hora")
     if re.search(r"\bfecha\b", texto):
-        return "fecha", None
+        return resultado("fecha", "fecha")
     if re.search(r"\bhora\b", texto):
-        return "hora", None
+        return resultado("hora", "hora")
     if re.search(r"\btiempo\b", texto):
-        return "fecha_hora", None
+        return resultado("fecha_hora", "tiempo")
 
     numero_comandos = {
         ("1", "uno"): "fecha_hora",
@@ -74,7 +77,7 @@ def interpretar(texto):
 
     for claves, comando in numero_comandos.items():
         if texto in claves:
-            return comando, None
+            return resultado(comando, texto)
 
     palabras_clave = {
         ("tiempo",): "fecha_hora",
@@ -119,7 +122,8 @@ def interpretar(texto):
     }
 
     for palabras, comando in palabras_clave.items():
-        if any(p in texto for p in palabras):
-            return comando, None
+        coincidencia = next((p for p in palabras if p in texto), None)
+        if coincidencia:
+            return resultado(comando, coincidencia)
 
-    return "comando_no_reconocido", None
+    return resultado("comando_no_reconocido")

--- a/PROMPTY_3.0/views/gui.py
+++ b/PROMPTY_3.0/views/gui.py
@@ -963,8 +963,11 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
     def ejecutar_comando_desde_texto(self, texto):
         self.servicio_voz.detener()
         # Obtener la acción y limpiar la salida previa
-        comando, argumentos = interpretar(texto)
+        comando, argumentos, palabra_clave = interpretar(texto)
         self.text_output.clear()
+
+        if self._confirmar_o_usar_ia(comando, palabra_clave, texto):
+            return
 
         if comando == "editar_usuario":
             self.mostrar_editor_usuario()
@@ -1014,6 +1017,39 @@ class PROMTYWindow(ScalingMixin, QMainWindow):
         texto_limpio = quitar_colores(respuesta)
         self.text_output.append(texto_limpio)
         self.servicio_voz.hablar(texto_limpio)
+
+    def _confirmar_o_usar_ia(self, comando, palabra_clave, texto_original):
+        """Ofrece al usuario ejecutar el comando o recibir una respuesta de IA."""
+        if comando in {"comando_no_reconocido", "saludo"}:
+            return False
+
+        clave = palabra_clave or comando
+        mensaje = (
+            f"Detecté la palabra clave '{clave}', que activa el comando predeterminado "
+            f"""'{comando}'. ¿Prefieres ejecutar el comando o que responda con el servicio de IA?"""
+        )
+
+        dialogo = QMessageBox(self)
+        dialogo.setWindowTitle("Confirmar acción")
+        dialogo.setText(mensaje)
+        ejecutar_btn = dialogo.addButton("Ejecutar comando", QMessageBox.ButtonRole.AcceptRole)
+        ia_btn = dialogo.addButton("Usar IA", QMessageBox.ButtonRole.ActionRole)
+        dialogo.addButton(QMessageBox.StandardButton.Cancel)
+
+        dialogo.exec()
+        decision = dialogo.clickedButton()
+
+        if decision == ia_btn:
+            respuesta = self.asistente_ia.responder(texto_original)
+            self.mostrar_respuesta(respuesta)
+            return True
+
+        if decision is None or decision == dialogo.button(QMessageBox.StandardButton.Cancel):
+            self.text_output.append("Operación cancelada. Indícame cómo ayudarte.")
+            return True
+
+        self.text_output.append("✅ Ejecutaré el comando predeterminado.")
+        return False
 
     def actualizar_fuente(self, familia, tamano):
         self.font_family = familia

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -32,7 +32,10 @@ class VistaTerminal:
             self.asistente_voz.hablar(quitar_colores("Hola. Estoy listo para ayudarte."))
 
         while True:
-            comando, argumentos, texto_original = self.obtener_instruccion()
+            comando, argumentos, texto_original, palabra_clave = self.obtener_instruccion()
+
+            if self._confirmar_o_usar_ia(comando, palabra_clave, texto_original):
+                continue
 
             if comando == "modo_admin":
                 self.menu_admin()
@@ -137,8 +140,36 @@ class VistaTerminal:
         else:
             entrada = ""
 
-        comando, argumentos = interpretar(entrada)
-        return comando, argumentos, entrada
+        comando, argumentos, palabra_clave = interpretar(entrada)
+        return comando, argumentos, entrada, palabra_clave
+
+    def _confirmar_o_usar_ia(self, comando, palabra_clave, texto_original):
+        """Pregunta al usuario si desea ejecutar el comando o usar la IA."""
+        if comando in ["comando_no_reconocido", "saludo"]:
+            return False
+
+        clave = palabra_clave or comando
+        mensaje = (
+            f"🔎 Detecté la palabra clave '{clave}', que activa el comando predeterminado "
+            f"""'{comando}'. Si prefieres una respuesta específica con el servicio de IA, escribe 'ia'."""
+        )
+        print(mensaje)
+        if self.modo_respuesta in ["voz", "ambos"]:
+            self.asistente_voz.hablar(quitar_colores(mensaje))
+
+        decision = input(
+            "Pulsa Enter para ejecutar el comando o escribe 'ia' para una respuesta con IA: "
+        ).strip().lower()
+
+        if decision == "ia":
+            respuesta = self.asistente_ia.responder(texto_original)
+            print(respuesta)
+            if self.modo_respuesta in ["voz", "ambos"]:
+                self.asistente_voz.hablar(quitar_colores(respuesta))
+            return True
+
+        print("✅ Ejecutaré el comando predeterminado. Si necesitas otra cosa, dímelo.")
+        return False
 
     def salir_programa(self):
         mensaje = "👋 Hasta luego. Fue un placer ayudarte."

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -59,5 +59,10 @@ class TestInterpretador(unittest.TestCase):
     def test_desconocido(self):
         self.assertEqual(interpretar('xyz')[0], 'comando_no_reconocido')
 
+    def test_palabra_clave_reportada(self):
+        comando, _, palabra = interpretar('buscar receta en youtube')
+        self.assertEqual(comando, 'buscar_en_youtube')
+        self.assertEqual(palabra, 'youtube')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- track the keyword that activates each built-in command and return it from the interpreter
- ask users in terminal and GUI flows whether to run the detected command or use the AI service instead
- cover the new keyword reporting behavior with interpreter tests

## Testing
- python -m pytest tests/test_interpretador.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b62a381483328213dedb46b42041)