### PR TITLE
Make Prompty conversations more natural

### DIFF
--- a/PROMPTY_3.0/services/comandos_basicos.py
+++ b/PROMPTY_3.0/services/comandos_basicos.py
@@ -120,6 +120,20 @@ class ComandosBasicos:
             return f"https://music.youtube.com/search?q={busqueda.replace(' ', '+')}"
         return None
 
+    def _normalizar_destino(self, destino):
+        """Mapea sinónimos a destinos conocidos."""
+
+        destino = (destino or "").strip().lower()
+        equivalencias = {
+            "google": "navegador",
+            "web": "navegador",
+            "internet": "navegador",
+            "music": "musica",
+            "música": "musica",
+            "yt": "youtube",
+        }
+        return equivalencias.get(destino, destino or "navegador")
+
     def abrir_url(self, url, mensaje=None):
         """Abre la URL indicada y devuelve un mensaje apropiado."""
         if not re.match(r"^https?://", url):
@@ -135,8 +149,16 @@ class ComandosBasicos:
         except Exception as e:
             return f"❌ Error al abrir el navegador: {e}"
 
-    def reproducir_musica(self, entrada_manual_func=None):
+    def reproducir_musica(self, entrada_manual_func=None, termino=None, url=None):
         """Abre una búsqueda o URL en YouTube Music."""
+
+        if termino or url:
+            destino_url = url or self.construir_url(termino, "musica")
+            if not destino_url:
+                return "❌ No pude preparar la reproducción solicitada."
+            mensaje = f"Reproduciendo: {termino}" if termino else None
+            return self.abrir_url(destino_url, mensaje)
+
         entrada = entrada_manual_func or input
 
         opcion = entrada(
@@ -159,15 +181,26 @@ class ComandosBasicos:
 
         return self.abrir_url(url, mensaje)
 
-    def buscar_en_navegador_con_opcion(self, destino_predefinido=None, entrada_manual_func=None):
+    def buscar_en_navegador_con_opcion(self, destino_predefinido=None, entrada_manual_func=None, termino=None, url=None):
         entrada = entrada_manual_func or input
+        destino = self._normalizar_destino(destino_predefinido)
+
+        if termino or url:
+            if destino not in ["youtube", "navegador", "musica"]:
+                destino = "navegador"
+            destino_url = url or self.construir_url(termino, destino)
+            if not destino_url:
+                return "❌ No pude preparar la búsqueda solicitada."
+            nombre = "YouTube" if destino == "youtube" else ("YouTube Music" if destino == "musica" else "tu navegador")
+            mensaje = f"Buscando '{termino}' en {nombre}." if termino else None
+            return self.abrir_url(destino_url, mensaje)
 
         if not destino_predefinido:
-            destino = entrada(
-                "¿Dónde deseas buscar? (youtube, navegador o musica): "
-            ).strip().lower()
+            destino = self._normalizar_destino(
+                entrada("¿Dónde deseas buscar? (youtube, navegador o musica): ").strip().lower()
+            )
         else:
-            destino = destino_predefinido
+            destino = self._normalizar_destino(destino_predefinido)
 
         if destino not in ["youtube", "navegador", "musica"]:
             return "❌ Opción inválida."

--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -68,21 +68,46 @@ class GestorComandos:
         return self.basicos.abrir_con_opcion(entrada_manual_func=entrada_func)
 
     def _accion_buscar_en_youtube(self, args, entrada_func):
-        manual = entrada_func if not args else None
+        termino = self._obtener_termino(args)
+        url = self._obtener_url(args)
+        manual = entrada_func if not (termino or url) else None
         return self.basicos.buscar_en_navegador_con_opcion(
-            destino_predefinido="youtube", entrada_manual_func=manual
+            destino_predefinido="youtube",
+            entrada_manual_func=manual,
+            termino=termino,
+            url=url,
         )
 
     def _accion_buscar_general(self, args, entrada_func):
-        return self.basicos.buscar_en_navegador_con_opcion(entrada_manual_func=entrada_func)
+        termino = self._obtener_termino(args)
+        url = self._obtener_url(args)
+        manual = entrada_func if not (termino or url) else None
+        return self.basicos.buscar_en_navegador_con_opcion(
+            entrada_manual_func=manual,
+            termino=termino,
+            url=url,
+        )
 
     def _accion_buscar_en_navegador(self, args, entrada_func):
+        termino = self._obtener_termino(args)
+        url = self._obtener_url(args)
+        manual = entrada_func if not (termino or url) else None
         return self.basicos.buscar_en_navegador_con_opcion(
-            destino_predefinido="navegador", entrada_manual_func=entrada_func
+            destino_predefinido="navegador",
+            entrada_manual_func=manual,
+            termino=termino,
+            url=url,
         )
 
     def _accion_reproducir_musica(self, args, entrada_func):
-        return self.basicos.reproducir_musica(entrada_manual_func=entrada_func)
+        termino = self._obtener_termino(args)
+        url = self._obtener_url(args)
+        manual = entrada_func if not (termino or url) else None
+        return self.basicos.reproducir_musica(
+            entrada_manual_func=manual,
+            termino=termino,
+            url=url,
+        )
 
     def _accion_dato_curioso(self, args, entrada_func):
         return self.basicos.mostrar_dato_curioso()
@@ -92,3 +117,15 @@ class GestorComandos:
 
     def _accion_saludo(self, args, entrada_func):
         return self.basicos.responder_saludo()
+
+    def _obtener_termino(self, args):
+        if isinstance(args, dict):
+            return args.get("termino")
+        if isinstance(args, str):
+            return args
+        return None
+
+    def _obtener_url(self, args):
+        if isinstance(args, dict):
+            return args.get("url")
+        return None

--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -1,4 +1,31 @@
 import re
+from typing import Dict, Optional, Tuple
+
+
+def _extraer_busqueda(texto: str) -> Tuple[Optional[str], Optional[str]]:
+    """Identifica la búsqueda solicitada y su posible destino."""
+
+    patron = re.search(
+        r"buscar(?:me|nos|le)?\s+(?P<termino>.+?)(?:\s+en\s+(?P<destino>youtube|google|navegador|internet|web|musica|música|music))?$",
+        texto,
+    )
+    if patron:
+        termino = patron.group("termino")
+        destino = patron.group("destino")
+        return termino.strip(), (destino or "").strip()
+    return None, None
+
+
+def _extraer_reproduccion(texto: str) -> Optional[str]:
+    """Detecta peticiones de reproducción de música con lenguaje natural."""
+
+    patron = re.search(
+        r"(?:pon|ponme|reproduce|toca|coloca|escuchar|quiero escuchar|pone)\s+(?P<cancion>.+)",
+        texto,
+    )
+    if patron:
+        return patron.group("cancion").strip()
+    return None
 
 
 def interpretar(texto):
@@ -7,13 +34,15 @@ def interpretar(texto):
     Si no se reconoce la orden, el comando será "comando_no_reconocido",
     los argumentos serán None y la palabra clave será None.
     """
+
     texto = texto.lower().strip()
     texto = texto.replace("en el", "en")  # Normaliza "buscar en el navegador" → "buscar en navegador"
 
     texto_simple = re.sub(r"[!.,?]", "", texto).strip()
 
-    def resultado(comando, palabra_clave=None):
-        return comando, None, palabra_clave
+    def resultado(comando, palabra_clave=None, argumentos: Optional[Dict[str, str]] = None):
+        return comando, argumentos, palabra_clave
+
     saludos = [
         "hola",
         "hola prompty",
@@ -28,6 +57,37 @@ def interpretar(texto):
 
     if "administrador" in texto and "funciones" in texto:
         return resultado("modo_admin", "funciones de administrador")
+
+    termino_busqueda, destino_busqueda = _extraer_busqueda(texto)
+    if termino_busqueda:
+        destino_busqueda = destino_busqueda or ""
+        if "youtube" in destino_busqueda:
+            return resultado(
+                "buscar_en_youtube",
+                "youtube",
+                {"termino": termino_busqueda},
+            )
+        if destino_busqueda in ("google", "navegador", "internet", "web"):
+            return resultado(
+                "buscar_en_navegador",
+                destino_busqueda or "navegador",
+                {"termino": termino_busqueda},
+            )
+        if destino_busqueda in ("musica", "música", "music"):
+            return resultado(
+                "reproducir_musica",
+                destino_busqueda,
+                {"termino": termino_busqueda},
+            )
+        return resultado(
+            "buscar_general",
+            "buscar",
+            {"termino": termino_busqueda},
+        )
+
+    cancion = _extraer_reproduccion(texto)
+    if cancion:
+        return resultado("reproducir_musica", "musica", {"termino": cancion})
 
     if "buscar" in texto:
         if "youtube" in texto:

--- a/PROMPTY_3.0/views/terminal.py
+++ b/PROMPTY_3.0/views/terminal.py
@@ -34,9 +34,6 @@ class VistaTerminal:
         while True:
             comando, argumentos, texto_original, palabra_clave = self.obtener_instruccion()
 
-            if self._confirmar_o_usar_ia(comando, palabra_clave, texto_original):
-                continue
-
             if comando == "modo_admin":
                 self.menu_admin()
                 continue
@@ -66,9 +63,13 @@ class VistaTerminal:
 
             if comando == "comando_no_reconocido":
                 respuesta = self.asistente_ia.responder(texto_original)
-                print(respuesta)
-                if self.modo_respuesta in ["voz", "ambos"]:
-                    self.asistente_voz.hablar(quitar_colores(respuesta))
+                self._responder(respuesta)
+                continue
+
+            if comando == "saludo":
+                respuesta = self.gestor_comandos.ejecutar_comando(comando, argumentos)
+                self._responder(respuesta)
+                self._registrar_historial(texto_original, respuesta)
                 continue
 
             # Comandos que requieren entrada
@@ -80,15 +81,14 @@ class VistaTerminal:
                 "buscar_en_navegador",
                 "reproducir_musica",
             ]
+            self._anunciar_accion(comando, argumentos, palabra_clave)
             if comando in comandos_interactivos:
                 respuesta = self.gestor_comandos.ejecutar_comando(comando, argumentos, entrada_manual_func=input)
             else:
                 respuesta = self.gestor_comandos.ejecutar_comando(comando, argumentos)
 
-            if self.modo_respuesta in ["texto", "ambos"]:
-                print(respuesta)
-            if self.modo_respuesta in ["voz", "ambos"]:
-                self.asistente_voz.hablar(quitar_colores(respuesta))
+            self._responder(respuesta)
+            self._registrar_historial(texto_original, respuesta)
 
             input("\nPresiona Enter para continuar...")
             limpiar_pantalla()
@@ -143,40 +143,38 @@ class VistaTerminal:
         comando, argumentos, palabra_clave = interpretar(entrada)
         return comando, argumentos, entrada, palabra_clave
 
-    def _confirmar_o_usar_ia(self, comando, palabra_clave, texto_original):
-        """Pregunta al usuario si desea ejecutar el comando o usar la IA."""
-        if comando in ["comando_no_reconocido", "saludo"]:
-            return False
-
-        clave = palabra_clave or comando
-        mensaje = (
-            f"🔎 Detecté la palabra clave '{clave}', que activa el comando predeterminado "
-            f"""'{comando}'. Si prefieres una respuesta específica con el servicio de IA, escribe 'ia'."""
-        )
-        print(mensaje)
-        if self.modo_respuesta in ["voz", "ambos"]:
-            self.asistente_voz.hablar(quitar_colores(mensaje))
-
-        decision = input(
-            "Pulsa Enter para ejecutar el comando o escribe 'ia' para una respuesta con IA: "
-        ).strip().lower()
-
-        if decision == "ia":
-            respuesta = self.asistente_ia.responder(texto_original)
-            print(respuesta)
-            if self.modo_respuesta in ["voz", "ambos"]:
-                self.asistente_voz.hablar(quitar_colores(respuesta))
-            return True
-
-        print("✅ Ejecutaré el comando predeterminado. Si necesitas otra cosa, dímelo.")
-        return False
-
     def salir_programa(self):
         mensaje = "👋 Hasta luego. Fue un placer ayudarte."
         print(mensaje)
         if self.modo_respuesta in ["voz", "ambos"]:
             self.asistente_voz.hablar(quitar_colores(mensaje))
         return "exit"
+
+    def _responder(self, mensaje: str):
+        if self.modo_respuesta in ["texto", "ambos"]:
+            print(mensaje)
+        if self.modo_respuesta in ["voz", "ambos"]:
+            self.asistente_voz.hablar(quitar_colores(mensaje))
+
+    def _registrar_historial(self, entrada, respuesta):
+        """Añade la interacción al historial de IA para conversaciones fluidas."""
+
+        if not entrada or not respuesta:
+            return
+        self.asistente_ia.historial.append({"rol": "usuario", "contenido": entrada})
+        self.asistente_ia.historial.append({"rol": "asistente", "contenido": quitar_colores(respuesta)})
+
+    def _anunciar_accion(self, comando, argumentos, palabra_clave):
+        """Comunica la acción detectada con un tono conversacional."""
+
+        termino = None
+        if isinstance(argumentos, dict):
+            termino = argumentos.get("termino")
+        if comando in ["buscar_en_youtube", "buscar_en_navegador", "buscar_general"] and termino:
+            destino = "YouTube" if comando == "buscar_en_youtube" else "el navegador"
+            self._responder(f"🚀 Entendido. Buscaré '{termino}' en {destino}.")
+        if comando == "reproducir_musica" and termino:
+            self._responder(f"🎵 Claro, reproduzco '{termino}' en YouTube Music.")
 
     def mostrar_bienvenida(self):
         print(f"{Fore.CYAN}¡Hola! Soy PROMPTY 3.0, tu asistente virtual de escritorio.{Style.RESET_ALL}")

--- a/tests/test_comandos_basicos.py
+++ b/tests/test_comandos_basicos.py
@@ -56,3 +56,25 @@ def test_reproducir_musica(monkeypatch):
     entrada = lambda msg="": next(vals)
     assert cb.reproducir_musica(entrada) == "🌐 Buscando: cancion"
     assert opened["url"] == "https://music.youtube.com/search?q=cancion"
+
+
+def test_reproducir_musica_directo(monkeypatch):
+    opened = {}
+    monkeypatch.setattr(comandos_basicos.shutil, "which", lambda _: None)
+    monkeypatch.setattr(comandos_basicos.webbrowser, "open", lambda url: opened.setdefault("url", url))
+
+    cb = comandos_basicos.ComandosBasicos()
+    resultado = cb.reproducir_musica(termino="lofi hip hop")
+    assert resultado.startswith("🌐 Reproduciendo:")
+    assert opened["url"] == "https://music.youtube.com/search?q=lofi+hip+hop"
+
+
+def test_buscar_con_termino_directo(monkeypatch):
+    opened = {}
+    monkeypatch.setattr(comandos_basicos.shutil, "which", lambda _: None)
+    monkeypatch.setattr(comandos_basicos.webbrowser, "open", lambda url: opened.setdefault("url", url))
+
+    cb = comandos_basicos.ComandosBasicos()
+    resultado = cb.buscar_en_navegador_con_opcion(destino_predefinido="youtube", termino="perritos divertidos")
+    assert resultado.startswith("🌐 Buscando 'perritos divertidos' en YouTube.")
+    assert opened["url"] == "https://www.youtube.com/results?search_query=perritos+divertidos"

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -64,5 +64,15 @@ class TestInterpretador(unittest.TestCase):
         self.assertEqual(comando, 'buscar_en_youtube')
         self.assertEqual(palabra, 'youtube')
 
+    def test_frases_conversacionales(self):
+        comando, args, palabra = interpretar('búscame gatitos adorables en YouTube')
+        self.assertEqual(comando, 'buscar_en_youtube')
+        self.assertEqual(palabra, 'youtube')
+        self.assertEqual(args.get('termino'), 'gatitos adorables')
+
+        comando, args, _ = interpretar('pon la canción imagine dragons')
+        self.assertEqual(comando, 'reproducir_musica')
+        self.assertEqual(args.get('termino'), 'la canción imagine dragons')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extract intents and arguments from frases conversacionales para búsquedas y música
- habilitar ejecución directa de comandos con términos detectados y respuestas previas conversacionales
- actualizar la vista de terminal y pruebas para reflejar la interacción más natural

## Testing
- uv run pytest *(falla: falta la cabecera de desarrollo de PortAudio al compilar pyaudio)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c034c61c83328d87d490145ef9ef)