### PR TITLE
Fix destination-only search parsing

### DIFF
--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -65,6 +65,16 @@ def interpretar(texto):
         return resultado("modo_admin", "funciones de administrador")
 
     termino_busqueda, destino_busqueda = _extraer_busqueda(texto)
+
+    if termino_busqueda and not destino_busqueda:
+        destino_detectado = re.match(
+            r"en\s+(youtube|google|navegador|internet|web|musica|música|music)\b",
+            termino_busqueda,
+        )
+        if destino_detectado:
+            termino_busqueda = None
+            destino_busqueda = destino_detectado.group(1)
+
     if termino_busqueda:
         destino_busqueda = destino_busqueda or ""
         if "youtube" in destino_busqueda:

--- a/tests/test_interpretador.py
+++ b/tests/test_interpretador.py
@@ -27,6 +27,17 @@ class TestInterpretador(unittest.TestCase):
         self.assertEqual(interpretar('poner cancion')[0], 'reproducir_musica')
         self.assertEqual(interpretar('oir canciones')[0], 'reproducir_musica')
 
+    def test_busqueda_sin_termino_con_destino(self):
+        comando, args, destino = interpretar('buscar en youtube')
+        self.assertEqual(comando, 'buscar_en_youtube')
+        self.assertIsNone(args)
+        self.assertEqual(destino, 'youtube')
+
+        comando, args, destino = interpretar('buscar en google')
+        self.assertEqual(comando, 'buscar_en_navegador')
+        self.assertIsNone(args)
+        self.assertEqual(destino, 'navegador')
+
     def test_admin_frase(self):
         resultado = interpretar('abre las funciones de administrador')[0]
         self.assertEqual(resultado, 'modo_admin')


### PR DESCRIPTION
## Summary
- handle destination-only search phrases without pre-filling incorrect terms
- add regression tests for search requests that only specify a destination

## Testing
- python -m unittest tests.test_interpretador


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c84239cc8332a77874b0a6cc4a85)