### PR TITLE
Add command endpoint that executes supported actions

### DIFF
--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -9,6 +9,8 @@ from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from ai import ServicioIA
+from services.gestor_comandos import GestorComandos
+from services.interpretador import interpretar
 
 app = FastAPI(
     title="PROMPTY AI Service",
@@ -20,6 +22,7 @@ app = FastAPI(
 )
 
 servicio_ia = ServicioIA()
+gestor_comandos = GestorComandos()
 
 
 class MensajeHistorial(BaseModel):
@@ -35,6 +38,18 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     respuesta: str
     exito: bool
+
+
+class CommandRequest(BaseModel):
+    texto: str = Field(..., min_length=1)
+    forzar_ejecucion: bool = False
+
+
+class CommandResponse(BaseModel):
+    comando: str
+    resultado: str
+    exito: bool
+    origen: str
 
 
 @app.get("/health")
@@ -56,9 +71,45 @@ async def chat(request: ChatRequest) -> ChatResponse:
     return ChatResponse(respuesta=respuesta, exito=exito)
 
 
+@app.post("/api/command", response_model=CommandResponse)
+async def command(request: CommandRequest) -> CommandResponse:
+    """Interpreta un texto y ejecuta el comando si está soportado."""
+
+    try:
+        comando, argumentos, _ = interpretar(request.texto)
+    except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    def _entrada_silenciosa(_: str = "") -> str:
+        return ""
+
+    if gestor_comandos.admite_comando(comando):
+        entrada = _entrada_silenciosa if request.forzar_ejecucion else None
+        resultado = await run_in_threadpool(
+            gestor_comandos.ejecutar_logica, comando, argumentos, entrada
+        )
+        exito = not (isinstance(resultado, str) and resultado.strip().startswith("❌"))
+        return CommandResponse(
+            comando=comando,
+            resultado=resultado,
+            exito=exito,
+            origen="gestor_comandos",
+        )
+
+    respuesta_ia, exito = await run_in_threadpool(
+        servicio_ia.consultar, request.texto, None
+    )
+    return CommandResponse(
+        comando=comando,
+        resultado=respuesta_ia,
+        exito=exito,
+        origen="ia",
+    )
+
+
 @app.get("/")
 async def root() -> dict:
     return {
         "mensaje": "PROMPTY API lista",
-        "endpoints": ["GET /health", "POST /api/chat"],
+        "endpoints": ["GET /health", "POST /api/chat", "POST /api/command"],
     }

--- a/PROMPTY_3.0/services/gestor_comandos.py
+++ b/PROMPTY_3.0/services/gestor_comandos.py
@@ -29,6 +29,11 @@ class GestorComandos:
     def establecer_usuario(self, usuario):
         self.usuario_actual = usuario
 
+    def admite_comando(self, clave_comando: str) -> bool:
+        """Indica si el gestor tiene una acción asociada al comando solicitado."""
+
+        return clave_comando in self._acciones
+
     def ejecutar_comando(self, clave_comando, argumentos=None, entrada_manual_func=None):
         """Ejecuta el comando indicado y devuelve el mensaje de respuesta."""
         return self.ejecutar_logica(clave_comando, argumentos, entrada_manual_func)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Endpoints principales:
 | --- | --- | --- |
 | `GET /health` | Verifica que el servicio esté activo. |
 | `POST /api/chat` | Envía un mensaje y recibe la respuesta de la IA. |
+| `POST /api/command` | Interpreta un texto, ejecuta comandos soportados y delega en la IA como fallback. |
 
 Ejemplo de consumo desde cualquier cliente HTTP:
 
@@ -125,6 +126,24 @@ curl -X POST http://localhost:8000/api/chat \
 ```
 
 La respuesta JSON contiene `respuesta` (texto generado) y `exito` (bandera booleana). Desde MyPlanU basta con realizar esta petición HTTP para reutilizar las capacidades de PROMPTY como microservicio.
+
+Nueva ruta de comandos (ejecuta acciones locales y sólo llama a la IA si el comando no está soportado):
+
+```bash
+curl -X POST http://localhost:8000/api/command \
+     -H "Content-Type: application/json" \
+     -d '{
+            "texto": "búscame vídeos de prompty en YouTube",
+            "forzar_ejecucion": true
+        }'
+```
+
+Parámetros:
+
+* `texto` (string): frase a interpretar por el motor de comandos.
+* `forzar_ejecucion` (bool, opcional): cuando es `true`, omite confirmaciones interactivas siempre que sea posible y ejecuta la acción directamente.
+
+Si el texto corresponde a una búsqueda en YouTube o al navegador, el servicio abre la URL correspondiente, por ejemplo redirigiendo a la página de resultados de YouTube con el término solicitado. Si no se reconoce el comando, se usa el mismo `ServicioIA` que en `/api/chat` como respuesta de respaldo.
 
 ---
 


### PR DESCRIPTION
## Summary
- add POST /api/command endpoint that interprets text, executes supported commands, and falls back to AI responses
- expose command support check in GestorComandos and allow forced execution without prompts
- document the new endpoint and examples in the API README section

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c83c201448332aca5c74b4692732c)