### PR TITLE
Adapt smart chat action handling

### DIFF
--- a/PROMPTY_3.0/ai/service.py
+++ b/PROMPTY_3.0/ai/service.py
@@ -11,7 +11,7 @@ from prompty_core.comandos import ACCIONES_DISPONIBLES
 
 from .config import CONFIG_LOCAL_PATH, IAConfig
 
-_SYSTEM_PROMPT = (
+_CHAT_SYSTEM_PROMPT = (
     "PROMPTY es un asistente virtual de escritorio desarrollado en Python. "
     "Su función principal es ayudar a los usuarios a realizar tareas cotidianas como abrir archivos, "
     "mostrar la hora, buscar en YouTube y ofrecer datos curiosos, respondiendo tanto por texto como por voz. "
@@ -22,18 +22,41 @@ _SYSTEM_PROMPT = (
     "Actúa siempre de forma clara y concisa, sin inventar datos ni enlaces que no existan."
 )
 
-_ACTION_SYSTEM_PROMPT = (
-    "Eres PROMPTY, un asistente local que decide qué acción ejecutar en el equipo. "
-    "Analiza la solicitud del usuario y responde únicamente con JSON válido siguiendo esta estructura: "
-    '{"accion": "<accion>", "parametros": {}, "respuesta_usuario": "<mensaje>"}. '
-    "Las acciones permitidas son: "
-    f"{', '.join(ACCIONES_DISPONIBLES)}. "
-    "Usa 'abrir_youtube' cuando debas abrir YouTube con una búsqueda (parametros: {\"query\": \"texto\"}). "
-    "Usa 'decir_hora' cuando pidan la hora (parametros vacío: {}). "
-    "Cuando no proceda acción alguna devuelve 'accion': 'ninguna'. "
-    "No inventes acciones nuevas, no añadas texto fuera del JSON, evita explicaciones adicionales y no uses Markdown. "
-    "La clave 'respuesta_usuario' debe contener un mensaje amable y breve en español para mostrar al usuario."
-)
+_SYSTEM_PROMPT = """
+Eres PROMPTY, un asistente de escritorio en español.
+
+Tu misión es:
+1) Interpretar lo que quiere el usuario.
+2) Decidir si se debe ejecutar una acción local.
+3) Responder SIEMPRE en JSON, con este formato EXACTO:
+
+{
+  "accion": "ninguna" | "abrir_youtube" | "decir_hora",
+  "parametros": {},
+  "respuesta_usuario": "texto a mostrar al usuario"
+}
+
+Reglas importantes:
+- NO agregues texto fuera del JSON.
+- Si el usuario quiere buscar algo en YouTube:
+    accion = "abrir_youtube"
+    parametros = {"query": "<texto a buscar>"}
+- Si el usuario pregunta la hora:
+    accion = "decir_hora"
+    parametros = {}
+- Si solo conversa:
+    accion = "ninguna"
+- No inventes acciones que no estén en esta lista.
+"""
+
+_DEFAULT_JSON_RESPONSE = {
+    "accion": "ninguna",
+    "parametros": {},
+    "respuesta_usuario": (
+        "Tuve un problema interpretando la respuesta de la IA. "
+        "¿Podrías repetir lo que necesitas?"
+    ),
+}
 
 
 class ServicioIA:
@@ -60,7 +83,7 @@ class ServicioIA:
         self,
         mensaje: str,
         historial: Optional[List[Dict[str, str]]],
-        system_prompt: str,
+        system_prompt: str = _CHAT_SYSTEM_PROMPT,
     ) -> List[Dict[str, str]]:
         mensajes: List[Dict[str, str]] = [
             {"role": "system", "content": system_prompt}
@@ -78,11 +101,13 @@ class ServicioIA:
         self,
         mensaje: str,
         historial: Optional[List[Dict[str, str]]],
-        system_prompt: str,
+        system_prompt: str = _CHAT_SYSTEM_PROMPT,
     ) -> Dict[str, Any]:
         return {
             "model": self.config.model_id,
-            "messages": self._build_messages(mensaje, historial, system_prompt),
+            "messages": self._build_messages(
+                mensaje, historial, system_prompt or _CHAT_SYSTEM_PROMPT
+            ),
             "temperature": self.config.temperature,
             "max_tokens": self.config.max_new_tokens,
         }
@@ -155,43 +180,35 @@ class ServicioIA:
     def consultar(
         self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
     ) -> tuple[str, bool]:
-        return self._consultar_modelo(mensaje, historial, _SYSTEM_PROMPT)
+        return self._consultar_modelo(mensaje, historial, _CHAT_SYSTEM_PROMPT)
 
-    def decidir_accion(
+    def consultar_inteligente(
         self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
     ) -> Dict[str, Any]:
-        texto, exito = self._consultar_modelo(mensaje, historial, _ACTION_SYSTEM_PROMPT)
+        texto, exito = self._consultar_modelo(mensaje, historial, _SYSTEM_PROMPT)
         if not exito:
-            return {
-                "accion": "ninguna",
-                "parametros": {},
-                "respuesta_usuario": texto,
-                "exito": False,
-            }
+            fallback = dict(_DEFAULT_JSON_RESPONSE)
+            fallback["respuesta_usuario"] = texto or fallback["respuesta_usuario"]
+            return fallback
 
         try:
             data = json.loads(texto)
         except ValueError:
-            return {
-                "accion": "ninguna",
-                "parametros": {},
-                "respuesta_usuario": texto,
-                "exito": False,
-            }
+            return dict(_DEFAULT_JSON_RESPONSE)
 
         accion = str(data.get("accion", "ninguna") or "ninguna").strip()
-        if accion not in ACCIONES_DISPONIBLES:
-            accion = "ninguna"
         parametros = data.get("parametros") if isinstance(data, dict) else {}
         if not isinstance(parametros, dict):
             parametros = {}
         respuesta_usuario = str(data.get("respuesta_usuario") or "").strip()
         if not respuesta_usuario:
-            respuesta_usuario = "Aquí tienes la respuesta solicitada."
+            respuesta_usuario = _DEFAULT_JSON_RESPONSE["respuesta_usuario"]
+
+        if accion not in ACCIONES_DISPONIBLES:
+            accion = "ninguna"
 
         return {
             "accion": accion,
             "parametros": parametros,
             "respuesta_usuario": respuesta_usuario,
-            "exito": True,
         }

--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -9,7 +9,8 @@ from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from ai import ServicioIA
-from prompty_core import ACCIONES_DISPONIBLES, ejecutar_accion
+from prompty_core import ACCIONES_DISPONIBLES
+from prompty_core.comandos import abrir_youtube, obtener_hora_actual
 from services.gestor_comandos import GestorComandos
 from services.interpretador import interpretar
 
@@ -47,10 +48,7 @@ class SmartChatRequest(BaseModel):
 
 
 class SmartChatResponse(BaseModel):
-    accion: str
-    respuesta_usuario: str
-    resultado_accion: Optional[str] = None
-    exito: bool
+    respuesta: str
 
 
 class CommandRequest(BaseModel):
@@ -88,7 +86,7 @@ async def chat(request: ChatRequest) -> ChatResponse:
 async def chat_inteligente(request: SmartChatRequest) -> SmartChatResponse:
     try:
         decision = await run_in_threadpool(
-            servicio_ia.decidir_accion,
+            servicio_ia.consultar_inteligente,
             request.mensaje,
             [
                 {"rol": h.rol, "contenido": h.contenido} for h in request.historial or []
@@ -97,44 +95,35 @@ async def chat_inteligente(request: SmartChatRequest) -> SmartChatResponse:
     except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    accion = decision.get("accion") if isinstance(decision, dict) else "ninguna"
+    accion = str(decision.get("accion") if isinstance(decision, dict) else "ninguna").strip()
     parametros = decision.get("parametros") if isinstance(decision, dict) else {}
+    if not isinstance(parametros, dict):
+        parametros = {}
     respuesta_usuario = str(
         (decision.get("respuesta_usuario") if isinstance(decision, dict) else "") or ""
     ).strip()
-    decision_valida = bool(decision.get("exito", True)) if isinstance(decision, dict) else False
 
     if accion not in ACCIONES_DISPONIBLES:
         accion = "ninguna"
 
-    resultado_accion: Optional[str] = None
-    exito = decision_valida
-
-    if accion != "ninguna":
-        try:
-            resultado_accion = await run_in_threadpool(
-                ejecutar_accion, accion, parametros
-            )
-        except Exception as exc:  # pragma: no cover - seguridad adicional
-            resultado_accion = f"❌ No pude completar la acción: {exc}"
-
-        if isinstance(resultado_accion, str) and resultado_accion.strip():
-            exito = exito and not resultado_accion.strip().startswith("❌")
-            if respuesta_usuario:
-                respuesta_usuario = f"{respuesta_usuario}\n{resultado_accion}" \
-                    if resultado_accion else respuesta_usuario
-            else:
-                respuesta_usuario = resultado_accion
-
     if not respuesta_usuario:
-        respuesta_usuario = "Aquí tienes la respuesta solicitada."
+        respuesta_usuario = (
+            "Tuve un problema interpretando la respuesta de la IA. "
+            "¿Podrías repetir lo que necesitas?"
+        )
 
-    return SmartChatResponse(
-        accion=accion,
-        respuesta_usuario=respuesta_usuario,
-        resultado_accion=resultado_accion,
-        exito=exito,
-    )
+    if accion == "abrir_youtube":
+        query = str(parametros.get("query", "")).strip()
+        if query:
+            await run_in_threadpool(abrir_youtube, query)
+    elif accion == "decir_hora":
+        hora_actual = obtener_hora_actual()
+        if "{hora}" in respuesta_usuario:
+            respuesta_usuario = respuesta_usuario.replace("{hora}", hora_actual)
+        elif "hora" not in respuesta_usuario.lower():
+            respuesta_usuario = f"{respuesta_usuario} Son las {hora_actual}."
+
+    return SmartChatResponse(respuesta=respuesta_usuario)
 
 
 @app.post("/api/command", response_model=CommandResponse)

--- a/PROMPTY_3.0/prompty_core/comandos.py
+++ b/PROMPTY_3.0/prompty_core/comandos.py
@@ -1,6 +1,7 @@
 """Acciones reutilizables para ejecutar comandos locales de PROMPTY."""
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 from services.comandos_basicos import ComandosBasicos
@@ -28,16 +29,20 @@ def _extraer_query(parametros: Optional[Dict[str, Any]]) -> Optional[str]:
     return None
 
 
-def _accion_abrir_youtube(parametros: Optional[Dict[str, Any]]) -> str:
-    query = _extraer_query(parametros)
-    if not query:
+def abrir_youtube(query: str) -> str:
+    termino = (query or "").strip()
+    if not termino:
         return "❌ No se especificó qué buscar en YouTube."
     return _comandos.buscar_en_navegador_con_opcion(
-        destino_predefinido="youtube", termino=query
+        destino_predefinido="youtube", termino=termino
     )
 
 
-def _accion_decir_hora(_: Optional[Dict[str, Any]]) -> str:
+def obtener_hora_actual() -> str:
+    return datetime.now().strftime("%H:%M")
+
+
+def decir_hora(_: Optional[Dict[str, Any]] = None) -> str:
     return _comandos.mostrar_hora()
 
 
@@ -49,8 +54,11 @@ def ejecutar_accion(accion: str, parametros: Optional[Dict[str, Any]] = None) ->
         accion_normalizada = "ninguna"
 
     if accion_normalizada == "abrir_youtube":
-        return _accion_abrir_youtube(parametros)
+        query = _extraer_query(parametros)
+        if not query:
+            return "❌ No se especificó qué buscar en YouTube."
+        return abrir_youtube(query)
     if accion_normalizada == "decir_hora":
-        return _accion_decir_hora(parametros)
+        return decir_hora(parametros)
 
     return "No hay acciones para ejecutar."


### PR DESCRIPTION
## Summary
- update the intelligent chat client prompt to return structured JSON for permitted actions and add robust parsing
- add centralized command helpers for opening YouTube searches and retrieving the current time
- adjust the FastAPI smart chat endpoint to execute local actions and return only the user-facing response

## Testing
- python -m pytest -q *(fails: missing optional dependencies httpx, num2words)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c89605660833289ae007d5385fcde)