### PR TITLE
Add structured interpreter wrapper for structured chat responses

### DIFF
--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+import logging
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
@@ -11,6 +12,7 @@ from pydantic import BaseModel, Field
 from ai import ServicioIA
 from prompty_core import ACCIONES_DISPONIBLES
 from prompty_core.comandos import abrir_youtube, obtener_hora_actual
+from core.interpretador_api import interpretar_mensaje_api
 from services.gestor_comandos import GestorComandos
 from services.interpretador import interpretar
 
@@ -25,21 +27,25 @@ app = FastAPI(
 
 servicio_ia = ServicioIA()
 gestor_comandos = GestorComandos()
+logger = logging.getLogger(__name__)
 
 
 class MensajeHistorial(BaseModel):
-    rol: str = Field(..., pattern="^(usuario|asistente|user|assistant)$")
+    rol: Literal["usuario", "asistente"]
     contenido: str = Field(..., min_length=1)
 
 
 class ChatRequest(BaseModel):
     mensaje: str = Field(..., min_length=1)
-    historial: Optional[List[MensajeHistorial]] = None
+    historial: List[MensajeHistorial] = Field(default_factory=list)
 
 
 class ChatResponse(BaseModel):
-    respuesta: str
     exito: bool
+    respuesta: str
+    accion: Optional[str] = None
+    parametros: Optional[Dict[str, Any]] = None
+    origen: Literal["interprete", "ia"]
 
 
 class SmartChatRequest(BaseModel):
@@ -71,15 +77,37 @@ async def healthcheck() -> dict:
 @app.post("/api/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest) -> ChatResponse:
     try:
-        respuesta, exito = await run_in_threadpool(
-            servicio_ia.consultar, request.mensaje, [
-                {"rol": h.rol, "contenido": h.contenido} for h in request.historial or []
-            ]
+        interpretacion = await run_in_threadpool(
+            interpretar_mensaje_api, request.mensaje
         )
     except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    return ChatResponse(respuesta=respuesta, exito=exito)
+    if interpretacion.accion:
+        return ChatResponse(
+            exito=True,
+            respuesta=interpretacion.texto_respuesta,
+            accion=interpretacion.accion,
+            parametros=interpretacion.parametros or {},
+            origen="interprete",
+        )
+
+    logger.info("[API] Mensaje enviado a IA externa")
+
+    try:
+        respuesta, exito = await run_in_threadpool(
+            servicio_ia.consultar,
+            request.mensaje,
+            [{"rol": h.rol, "contenido": h.contenido} for h in request.historial],
+        )
+    except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return ChatResponse(
+        exito=exito,
+        respuesta=respuesta,
+        origen="ia",
+    )
 
 
 @app.post("/api/chat-inteligente", response_model=SmartChatResponse)

--- a/PROMPTY_3.0/core/interpretador_api.py
+++ b/PROMPTY_3.0/core/interpretador_api.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from services.comandos_basicos import ComandosBasicos
+from services.interpretador import interpretar
+
+logger = logging.getLogger(__name__)
+
+_basicos = ComandosBasicos()
+
+
+@dataclass
+class ResultadoInterpretacion:
+    texto_respuesta: str
+    accion: Optional[str] = None
+    parametros: Optional[Dict[str, Any]] = None
+
+
+def _extraer_termino(argumentos: Optional[Dict[str, Any]]) -> Optional[str]:
+    if isinstance(argumentos, dict):
+        for clave in ("termino", "query", "busqueda"):
+            valor = argumentos.get(clave)
+            if isinstance(valor, str) and valor.strip():
+                return valor.strip()
+    if isinstance(argumentos, str) and argumentos.strip():
+        return argumentos.strip()
+    return None
+
+
+def interpretar_mensaje_api(mensaje: str) -> ResultadoInterpretacion:
+    comando, argumentos, _ = interpretar(mensaje)
+
+    parametros: Optional[Dict[str, Any]] = None
+    accion: Optional[str] = None
+    texto_respuesta: str
+
+    if comando == "hora":
+        accion = "decir_hora"
+        texto_respuesta = _basicos.mostrar_hora()
+    elif comando == "fecha":
+        accion = "decir_fecha"
+        texto_respuesta = _basicos.mostrar_fecha()
+    elif comando == "fecha_hora":
+        accion = "decir_fecha_hora"
+        texto_respuesta = _basicos.mostrar_fecha_hora()
+    elif comando == "dia_fecha":
+        accion = "decir_dia_fecha"
+        texto_respuesta = _basicos.mostrar_dia_fecha()
+    elif comando == "buscar_en_youtube":
+        termino = _extraer_termino(argumentos)
+        accion = "buscar_youtube"
+        parametros = {"query": termino} if termino else {}
+        texto_respuesta = (
+            f"🔎 Buscar en YouTube: {termino}" if termino else "¿Qué deseas buscar en YouTube?"
+        )
+    elif comando in ("buscar_en_navegador", "buscar_general"):
+        termino = _extraer_termino(argumentos)
+        accion = "buscar_navegador"
+        parametros = {"query": termino} if termino else {}
+        texto_respuesta = (
+            f"🔎 Buscar en el navegador: {termino}" if termino else "¿Qué deseas buscar en el navegador?"
+        )
+    elif comando == "reproducir_musica":
+        termino = _extraer_termino(argumentos)
+        accion = "reproducir_musica"
+        parametros = {"query": termino} if termino else {}
+        texto_respuesta = (
+            f"🎵 Reproducir en YouTube Music: {termino}"
+            if termino
+            else "¿Qué canción o artista quieres escuchar?"
+        )
+    elif comando == "dato_curioso":
+        accion = "dato_curioso"
+        texto_respuesta = _basicos.mostrar_dato_curioso()
+    elif comando == "saludo":
+        texto_respuesta = _basicos.responder_saludo()
+    else:
+        texto_respuesta = ""
+
+    if accion:
+        logger.info("[API] Mensaje interpretado: accion=%s, parametros=%s", accion, parametros or {})
+        return ResultadoInterpretacion(
+            texto_respuesta=texto_respuesta,
+            accion=accion,
+            parametros=parametros,
+        )
+
+    return ResultadoInterpretacion(texto_respuesta=texto_respuesta)


### PR DESCRIPTION
## Summary
- add an API-focused interpreter wrapper that reuses existing command logic without triggering UI actions
- update /api/chat to return structured responses with actions/parameters before falling back to the AI service
- add lightweight logging and request/response models suitable for MyPlanU integration

## Testing
- python -m compileall api core

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c90db3c5c8332805d072389298bb2)