### PR TITLE
Route chat API through real interpreter actions

### DIFF
--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional
+import json
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
@@ -12,7 +13,7 @@ from ai import ServicioIA
 from prompty_core import ACCIONES_DISPONIBLES
 from prompty_core.comandos import abrir_youtube, obtener_hora_actual
 from services.gestor_comandos import GestorComandos
-from services.interpretador import interpretar
+from services import interpretador
 
 app = FastAPI(
     title="PROMPTY AI Service",
@@ -33,14 +34,18 @@ class MensajeHistorial(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    Mensaje: str
-    Historial: Optional[List[Dict[str, str]]] = None
+    mensaje: str = Field(..., min_length=1, alias="mensaje")
+    historial: Optional[List[Dict[str, str]]] = Field(
+        default=None, alias="historial"
+    )
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class ChatResponse(BaseModel):
     respuesta: str
-    accion: Optional[str] = None
-    argumentos: Dict[str, Any] = Field(default_factory=dict)
+    exito: bool = True
 
 
 class SmartChatRequest(BaseModel):
@@ -64,51 +69,85 @@ class CommandResponse(BaseModel):
     origen: str
 
 
-def detectar_intencion(
+INTENCIONES_PERMITIDAS = {
+    "hora",
+    "fecha",
+    "fecha_hora",
+    "dia_fecha",
+    "abrir_navegador",
+    "buscar_en_navegador",
+    "buscar_general",
+    "buscar_youtube",
+    "reproducir_musica",
+    "dato_curioso",
+    "informacion",
+    "abrir_carpeta",
+    "abrir_archivo",
+    "abrir_con_opcion",
+    "salir",
+    "saludo",
+}
+
+
+CLASIFICADOR_SYSTEM_PROMPT = """
+Eres un asistente que SOLO clasifica intenciones en español.
+Debes devolver únicamente un JSON usando este formato exacto:
+{
+  "intencion": "hora|fecha|fecha_hora|abrir_navegador|buscar_youtube|reproducir_musica|dato_curioso|informacion|abrir_archivo|abrir_carpeta|salir|saludo",
+  "argumento": "texto opcional relacionado (busqueda, ruta, etc.)"
+}
+
+Reglas:
+- No inventes acciones fuera de la lista.
+- No devuelvas explicaciones ni texto fuera del JSON.
+- Usa "buscar_youtube" si quiere buscar o reproducir algo en YouTube.
+- Usa "abrir_navegador" para búsquedas o URLs genéricas.
+- Usa "reproducir_musica" para peticiones de música.
+- Si no reconoces la intención, usa "intencion": "saludo" cuando sea un saludo o "intencion": "dato_curioso" solo si lo pide, de lo contrario "intencion": ""
+- El modelo cliente ejecutará la acción real; tú solo clasificas.
+"""
+
+
+def _parsear_clasificacion(texto: str) -> Tuple[Optional[str], Optional[str]]:
+    if not texto:
+        return None, None
+
+    texto_limpio = texto.strip()
+    try:
+        data = json.loads(texto_limpio)
+        intencion = str(
+            data.get("intencion") or data.get("accion") or ""
+        ).strip().lower()
+        argumento = data.get("argumento") or data.get("query") or data.get("busqueda")
+    except ValueError:
+        intencion = texto_limpio.lower()
+        argumento = None
+
+    if intencion not in INTENCIONES_PERMITIDAS:
+        return None, None
+
+    if isinstance(argumento, str):
+        argumento = argumento.strip() or None
+
+    return intencion, argumento
+
+
+async def clasificar_intencion(
     mensaje: str, historial: Optional[List[Dict[str, str]]] = None
-) -> tuple[Optional[str], Dict[str, Any]]:
-    """
-    Devuelve (accion, argumentos) a partir del mensaje del usuario
-    y, si es necesario, usando el último mensaje del asistente.
-    Acciones soportadas:
-      - "decir_hora"
-      - "abrir_youtube"
-      - None (solo charla)
-    """
-
-    texto = (mensaje or "").lower()
-
-    if "hora" in texto or "qué hora es" in texto or "dime la hora" in texto:
-        return "decir_hora", {}
-
-    if "youtube" in texto or "video" in texto or "videos" in texto:
-        return "abrir_youtube", {"query": mensaje}
-
-    if texto.strip() in ("sí", "si", "dale", "ok") and historial:
-        ultimo_asistente = next(
-            (m for m in reversed(historial) if m.get("rol") == "asistente"),
-            None,
-        )
-        if ultimo_asistente:
-            contenido = (ultimo_asistente.get("contenido") or "").lower()
-            if "youtube" in contenido:
-                return "abrir_youtube", {"query": "búsqueda en youtube"}
-            if "hora actual" in contenido:
-                return "decir_hora", {}
-
-    return None, {}
-
-
-async def llamar_modelo(
-    system_prompt: str, mensaje: str, historial: Optional[List[Dict[str, str]]]
-) -> str:
-    texto_modelo, _ = await run_in_threadpool(
+) -> Tuple[Optional[str], Optional[str]]:
+    texto_modelo, exito = await run_in_threadpool(
         servicio_ia._consultar_modelo,  # noqa: SLF001 - uso interno controlado
         mensaje,
         historial,
-        system_prompt,
+        CLASIFICADOR_SYSTEM_PROMPT,
     )
-    return texto_modelo
+
+    if exito:
+        intencion, argumento = _parsear_clasificacion(texto_modelo)
+        if intencion:
+            return intencion, argumento
+
+    return interpretador.interpretar_intencion_local(mensaje)
 
 
 @app.get("/health")
@@ -118,31 +157,30 @@ async def healthcheck() -> dict:
 
 @app.post("/api/chat", response_model=ChatResponse)
 async def chat(req: ChatRequest) -> ChatResponse:
-    mensaje = req.Mensaje
-    historial = req.Historial
-
-    accion, argumentos = detectar_intencion(mensaje, historial)
-
-    system_prompt = (
-        "Eres PROMPTY, un asistente virtual de planificación integrado en otra aplicación.\n"
-        "Tu misión es responder en español con mensajes breves y claros.\n"
-        "NO digas la hora tú mismo, ni abras YouTube, ni ejecutes acciones reales.\n"
-        "Si el usuario pregunta la hora, responde algo como: "
-        "'Te digo la hora actual en la aplicación.' sin inventar la hora.\n"
-        "Si el usuario pide YouTube, responde algo como: "
-        "'Puedo abrir YouTube para buscar eso en tu dispositivo.'\n"
-        "El programa cliente se encargará de ejecutar los comandos basándose en la acción."
-    )
+    mensaje = req.mensaje
+    historial = req.historial
 
     try:
-        texto_modelo = await llamar_modelo(system_prompt, mensaje, historial)
+        intencion, argumento = await clasificar_intencion(mensaje, historial)
+    except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    if not intencion:
+        return ChatResponse(
+            respuesta="No pude entender tu solicitud. ¿Podrías reformularla?",
+            exito=False,
+        )
+
+    try:
+        respuesta, exito = await run_in_threadpool(
+            interpretador.ejecutar_intencion, intencion, argumento
+        )
     except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     return ChatResponse(
-        respuesta=texto_modelo,
-        accion=accion,
-        argumentos=argumentos,
+        respuesta=respuesta,
+        exito=exito,
     )
 
 
@@ -195,7 +233,7 @@ async def command(request: CommandRequest) -> CommandResponse:
     """Interpreta un texto y ejecuta el comando si está soportado."""
 
     try:
-        comando, argumentos, _ = interpretar(request.texto)
+        comando, argumentos, _ = interpretador.interpretar(request.texto)
     except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/PROMPTY_3.0/services/interpretador.py
+++ b/PROMPTY_3.0/services/interpretador.py
@@ -1,6 +1,11 @@
 import re
 from typing import Dict, Optional, Tuple
 
+from services.comandos_basicos import ComandosBasicos
+
+
+_basicos = ComandosBasicos()
+
 
 def _extraer_busqueda(texto: str) -> Tuple[Optional[str], Optional[str]]:
     """Identifica la búsqueda solicitada y su posible destino."""
@@ -205,3 +210,146 @@ def interpretar(texto):
             return resultado(comando, coincidencia)
 
     return resultado("comando_no_reconocido")
+
+
+def _normalizar_argumento(argumento: Optional[str]) -> Optional[str]:
+    if isinstance(argumento, str):
+        argumento = argumento.strip()
+        return argumento or None
+    return None
+
+
+def _entrada_silenciosa(_: str = "") -> str:
+    """Devuelve cadena vacía para evitar prompts interactivos en API."""
+
+    return ""
+
+
+def obtener_hora() -> str:
+    return _basicos.mostrar_hora()
+
+
+def obtener_fecha() -> str:
+    return _basicos.mostrar_fecha()
+
+
+def obtener_fecha_hora() -> str:
+    return _basicos.mostrar_fecha_hora()
+
+
+def abrir_navegador(busqueda: Optional[str] = None, url: Optional[str] = None) -> str:
+    termino = _normalizar_argumento(busqueda)
+    return _basicos.buscar_en_navegador_con_opcion(
+        destino_predefinido="navegador",
+        entrada_manual_func=_entrada_silenciosa,
+        termino=termino,
+        url=url,
+    )
+
+
+def buscar_youtube(busqueda: Optional[str] = None, url: Optional[str] = None) -> str:
+    termino = _normalizar_argumento(busqueda)
+    return _basicos.buscar_en_navegador_con_opcion(
+        destino_predefinido="youtube",
+        entrada_manual_func=_entrada_silenciosa,
+        termino=termino,
+        url=url,
+    )
+
+
+def reproducir_musica(busqueda: Optional[str] = None, url: Optional[str] = None) -> str:
+    termino = _normalizar_argumento(busqueda)
+    return _basicos.reproducir_musica(
+        entrada_manual_func=_entrada_silenciosa,
+        termino=termino,
+        url=url,
+    )
+
+
+def abrir_carpeta(ruta: Optional[str] = None) -> str:
+    ruta_normalizada = _normalizar_argumento(ruta)
+    if ruta_normalizada:
+        return _basicos.abrir_carpeta(ruta_normalizada)
+    return _basicos.abrir_con_opcion(tipo="carpeta", entrada_manual_func=_entrada_silenciosa)
+
+
+def abrir_archivo(ruta: Optional[str] = None) -> str:
+    ruta_normalizada = _normalizar_argumento(ruta)
+    if ruta_normalizada:
+        return _basicos.abrir_carpeta(ruta_normalizada)
+    return _basicos.abrir_con_opcion(
+        tipo="archivo",
+        entrada_manual_func=_entrada_silenciosa,
+    )
+
+
+def dato_curioso() -> str:
+    return _basicos.mostrar_dato_curioso()
+
+
+def informacion(opcion: Optional[str] = None) -> str:
+    seleccion = _normalizar_argumento(opcion) or "2"
+    return _basicos.info_sistema(entrada_manual_func=lambda _: seleccion)
+
+
+def salir() -> str:
+    return "👋 Hasta pronto."
+
+
+def interpretar_intencion_local(texto: str) -> Tuple[Optional[str], Optional[str]]:
+    """Usa el interpretador clásico para mapear el mensaje a una intención y argumento."""
+
+    comando, argumentos, palabra_clave = interpretar(texto)
+
+    if comando in {"hora", "fecha", "fecha_hora", "dia_fecha"}:
+        return comando, None
+    if comando in {"buscar_en_youtube", "buscar_general", "buscar_en_navegador"}:
+        if isinstance(argumentos, dict):
+            return comando, argumentos.get("termino")
+        return comando, palabra_clave
+    if comando == "reproducir_musica":
+        if isinstance(argumentos, dict):
+            return comando, argumentos.get("termino")
+        return comando, palabra_clave
+    if comando in {"abrir_carpeta", "abrir_archivo", "abrir_con_opcion"}:
+        return comando, palabra_clave
+    if comando in {"dato_curioso", "info_programa", "salir", "saludo"}:
+        return comando, None
+    return None, None
+
+
+def ejecutar_intencion(intencion: Optional[str], argumento: Optional[str] = None) -> Tuple[str, bool]:
+    """Ejecuta la intención solicitada y devuelve el texto y si fue exitosa."""
+
+    accion = (intencion or "").strip().lower()
+    texto: str
+
+    if accion in {"hora"}:
+        texto = obtener_hora()
+    elif accion in {"fecha"}:
+        texto = obtener_fecha()
+    elif accion in {"fecha_hora", "dia_fecha"}:
+        texto = obtener_fecha_hora()
+    elif accion in {"abrir_navegador", "buscar_en_navegador", "buscar_general"}:
+        texto = abrir_navegador(argumento)
+    elif accion in {"buscar_youtube", "buscar_en_youtube"}:
+        texto = buscar_youtube(argumento)
+    elif accion == "reproducir_musica":
+        texto = reproducir_musica(argumento)
+    elif accion in {"abrir_carpeta"}:
+        texto = abrir_carpeta(argumento)
+    elif accion in {"abrir_archivo", "abrir_con_opcion"}:
+        texto = abrir_archivo(argumento)
+    elif accion in {"dato_curioso"}:
+        texto = dato_curioso()
+    elif accion in {"informacion", "info_programa"}:
+        texto = informacion(argumento)
+    elif accion in {"salir"}:
+        texto = salir()
+    elif accion in {"saludo"}:
+        texto = _basicos.responder_saludo()
+    else:
+        texto = "❌ No pude reconocer la acción solicitada."
+
+    exito = not texto.strip().startswith("❌")
+    return texto, exito


### PR DESCRIPTION
## Summary
- classify chat intents via the LLM and delegate execution to the interpreter
- add real command execution helpers mirroring PROMPTY 2.0 behaviors
- update chat responses to return execution results with success flags

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9cc1e2208332a83b679e10695a07)