### PR TITLE
Handle local commands before calling AI

### DIFF
--- a/PROMPTY_3.0/ai/service.py
+++ b/PROMPTY_3.0/ai/service.py
@@ -12,14 +12,9 @@ from prompty_core.comandos import ACCIONES_DISPONIBLES
 from .config import CONFIG_LOCAL_PATH, IAConfig
 
 _CHAT_SYSTEM_PROMPT = (
-    "PROMPTY es un asistente virtual de escritorio desarrollado en Python. "
-    "Su función principal es ayudar a los usuarios a realizar tareas cotidianas como abrir archivos, "
-    "mostrar la hora, buscar en YouTube y ofrecer datos curiosos, respondiendo tanto por texto como por voz. "
-    "En el futuro se integrará con la aplicación MyPlanU (desarrollada en .NET y WinForms) a través de una API, "
-    "lo que le permitirá crear tareas y realizar acciones dentro de MyPlanU según las instrucciones del usuario. "
-    "Por ahora, si un usuario solicita algo relacionado con tareas, simplemente informa que esta funcionalidad estará disponible "
-    "próximamente mediante esa integración y que en el futuro podrá realizar esas tareas directamente en MyPlanU. "
-    "Actúa siempre de forma clara y concisa, sin inventar datos ni enlaces que no existan."
+    "Eres PROMPTY, un asistente de escritorio. Responde en español de forma clara "
+    "y breve. No describas acciones técnicas ni menciones limitaciones; habla "
+    "directamente al usuario con la información solicitada."
 )
 
 _SYSTEM_PROMPT = """

--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
+import webbrowser
+from datetime import date, datetime
 from typing import Any, Dict, List, Literal, Optional, Tuple
+from urllib.parse import quote_plus
 
 from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
@@ -14,6 +18,7 @@ from prompty_core import ACCIONES_DISPONIBLES
 from prompty_core.comandos import abrir_youtube, obtener_hora_actual
 from services.gestor_comandos import GestorComandos
 from services import interpretador
+from services import datos_curiosos
 
 app = FastAPI(
     title="PROMPTY AI Service",
@@ -26,6 +31,8 @@ app = FastAPI(
 
 servicio_ia = ServicioIA()
 gestor_comandos = GestorComandos()
+
+logger = logging.getLogger(__name__)
 
 
 class MensajeHistorial(BaseModel):
@@ -108,6 +115,85 @@ Reglas:
 """
 
 
+_MESES_ES = [
+    "enero",
+    "febrero",
+    "marzo",
+    "abril",
+    "mayo",
+    "junio",
+    "julio",
+    "agosto",
+    "septiembre",
+    "octubre",
+    "noviembre",
+    "diciembre",
+]
+
+_HORA_PATRONES = (
+    "que hora es",
+    "qué hora es",
+    "dime la hora",
+    "dime la hora actual",
+    "hora actual",
+)
+
+_FECHA_PATRONES = (
+    "que fecha es hoy",
+    "qué fecha es hoy",
+    "dime la fecha",
+    "dime la fecha de hoy",
+    "fecha de hoy",
+)
+
+
+def _hora_actual() -> str:
+    return datetime.now().strftime("%H:%M")
+
+
+def _fecha_actual() -> str:
+    hoy = date.today()
+    mes = _MESES_ES[hoy.month - 1]
+    return f"{hoy.day} de {mes} de {hoy.year}"
+
+
+def _extraer_busqueda_youtube(mensaje: str) -> str:
+    palabras = [p for p in mensaje.split() if p.lower() != "youtube"]
+    termino = " ".join(palabras).strip()
+    return termino or "YouTube"
+
+
+def resolver_comando_local(mensaje: str) -> Optional[str]:
+    """
+    Si el mensaje coincide con un comando soportado (hora, fecha, youtube,
+    dato curioso), devuelve el texto de respuesta ya listo.
+    Si no coincide con nada, devuelve None.
+    """
+
+    if not mensaje:
+        return None
+
+    mensaje_limpio = mensaje.strip()
+    mensaje_minusculas = mensaje_limpio.lower()
+
+    if any(patron in mensaje_minusculas for patron in _HORA_PATRONES):
+        return f"La hora actual es: {_hora_actual()}"
+
+    if any(patron in mensaje_minusculas for patron in _FECHA_PATRONES):
+        return f"Hoy es {_fecha_actual()}"
+
+    if "youtube" in mensaje_minusculas:
+        termino = _extraer_busqueda_youtube(mensaje_limpio)
+        url = "https://www.youtube.com/results?search_query=" + quote_plus(termino)
+        webbrowser.open(url)
+        return f"Abriendo YouTube para buscar: {termino}"
+
+    if "dato curioso" in mensaje_minusculas:
+        return datos_curiosos.mostrar_curiosidad()
+
+    return None
+
+
 def _parsear_clasificacion(texto: str) -> Tuple[Optional[str], Optional[str]]:
     if not texto:
         return None, None
@@ -161,27 +247,32 @@ async def chat(req: ChatRequest) -> ChatResponse:
     historial = req.historial
 
     try:
+        respuesta_local = resolver_comando_local(mensaje)
+        if respuesta_local is not None:
+            return ChatResponse(respuesta=respuesta_local, exito=True)
+
         intencion, argumento = await clasificar_intencion(mensaje, historial)
-    except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    if not intencion:
-        return ChatResponse(
-            respuesta="No pude entender tu solicitud. ¿Podrías reformularla?",
-            exito=False,
-        )
+        if not intencion:
+            return ChatResponse(
+                respuesta="No pude entender tu solicitud. ¿Podrías reformularla?",
+                exito=False,
+            )
 
-    try:
         respuesta, exito = await run_in_threadpool(
             interpretador.ejecutar_intencion, intencion, argumento
         )
-    except Exception as exc:  # pragma: no cover - FastAPI convertirá en JSON
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    return ChatResponse(
-        respuesta=respuesta,
-        exito=exito,
-    )
+        return ChatResponse(
+            respuesta=respuesta,
+            exito=exito,
+        )
+    except Exception as exc:  # pragma: no cover - se devuelve error controlado
+        logger.exception("Error procesando /api/chat: %s", exc)
+        return ChatResponse(
+            respuesta="Ocurrió un error al procesar tu solicitud.",
+            exito=False,
+        )
 
 
 @app.post("/api/chat-inteligente", response_model=SmartChatResponse)


### PR DESCRIPTION
## Summary
- add local command resolution for /api/chat to return immediate responses for hora, fecha, YouTube y datos curiosos
- adjust error handling to log failures and return standardized error responses
- simplify chat system prompts to remove artificial limitations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9ff76a948332a1121ada8a1763ce)