### PR TITLE
Add PROMPTY Lite prompt for API server

### DIFF
--- a/PROMPTY_3.0/ai/service.py
+++ b/PROMPTY_3.0/ai/service.py
@@ -17,7 +17,19 @@ _CHAT_SYSTEM_PROMPT = (
     "directamente al usuario con la información solicitada."
 )
 
-_SYSTEM_PROMPT = """
+_SYSTEM_PROMPT = (
+    "Eres PROMPTY Lite, una versión limitada de un asistente de escritorio en español. "
+    "Tu función es mantener una conversación clara y útil con el usuario, "
+    "dando explicaciones y pasos concretos en menos de 200 palabras. "
+    "No tienes acceso al sistema operativo, no puedes abrir aplicaciones, "
+    "no puedes ver la hora real ni manejar archivos o carpetas. "
+    "Si el usuario te pide hacer algo que requiera acceso al sistema, "
+    "explícale que esta versión solo puede dar indicaciones y recomiéndale "
+    "usar la versión completa de PROMPTY instalada en su computadora. "
+    "Nunca finjas que ejecutas acciones reales; solo describe lo que el usuario podría hacer."
+)
+
+_AUTOMATION_SYSTEM_PROMPT = """
 Eres PROMPTY, un asistente de escritorio en español.
 
 Tu misión es:
@@ -177,10 +189,17 @@ class ServicioIA:
     ) -> tuple[str, bool]:
         return self._consultar_modelo(mensaje, historial, _CHAT_SYSTEM_PROMPT)
 
+    def consultar_lite(
+        self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
+    ) -> tuple[str, bool]:
+        return self._consultar_modelo(mensaje, historial, _SYSTEM_PROMPT)
+
     def consultar_inteligente(
         self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
     ) -> Dict[str, Any]:
-        texto, exito = self._consultar_modelo(mensaje, historial, _SYSTEM_PROMPT)
+        texto, exito = self._consultar_modelo(
+            mensaje, historial, _AUTOMATION_SYSTEM_PROMPT
+        )
         if not exito:
             fallback = dict(_DEFAULT_JSON_RESPONSE)
             fallback["respuesta_usuario"] = texto or fallback["respuesta_usuario"]

--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -78,7 +78,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
 
     try:
         respuesta, exito = await run_in_threadpool(
-            servicio_ia.consultar, mensaje, historial
+            servicio_ia.consultar_lite, mensaje, historial
         )
         return ChatResponse(respuesta=respuesta, exito=exito)
     except Exception as exc:  # pragma: no cover - se devuelve error controlado
@@ -93,7 +93,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
 async def chat_inteligente(request: SmartChatRequest) -> SmartChatResponse:
     try:
         respuesta, _ = await run_in_threadpool(
-            servicio_ia.consultar,
+            servicio_ia.consultar_lite,
             request.mensaje,
             [
                 {"rol": h.rol, "contenido": h.contenido} for h in request.historial or []
@@ -109,7 +109,7 @@ async def command(request: CommandRequest) -> CommandResponse:
     """Responde usando la IA sin ejecutar acciones locales."""
 
     respuesta_ia, exito = await run_in_threadpool(
-        servicio_ia.consultar, request.texto, None
+        servicio_ia.consultar_lite, request.texto, None
     )
     return CommandResponse(
         comando="sin_ejecucion",


### PR DESCRIPTION
## Summary
- update the Hugging Face system prompt to reflect PROMPTY Lite constraints
- keep the desktop automation prompt intact via a dedicated constant and method
- route API endpoints through the lite prompt intended for MyPlanU

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbd05971083329b08c760ba1ea902)