### PR TITLE
Ensure PROMPTY Lite API stays conversational

### DIFF
--- a/PROMPTY_3.0/ai/service.py
+++ b/PROMPTY_3.0/ai/service.py
@@ -143,7 +143,7 @@ class ServicioIA:
                     return f"❌ {candidato['error']}"
         return None
 
-    def _consultar_modelo(
+    def _consultar_conversacion(
         self, mensaje: str, historial: Optional[List[Dict[str, str]]], system_prompt: str
     ) -> tuple[str, bool]:
         mensaje = (mensaje or "").strip()
@@ -184,20 +184,10 @@ class ServicioIA:
 
         return texto.strip(), True
 
-    def consultar(
-        self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
-    ) -> tuple[str, bool]:
-        return self._consultar_modelo(mensaje, historial, _CHAT_SYSTEM_PROMPT)
-
-    def consultar_lite(
-        self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
-    ) -> tuple[str, bool]:
-        return self._consultar_modelo(mensaje, historial, _SYSTEM_PROMPT)
-
-    def consultar_inteligente(
+    def _consultar_automatizacion(
         self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
     ) -> Dict[str, Any]:
-        texto, exito = self._consultar_modelo(
+        texto, exito = self._consultar_conversacion(
             mensaje, historial, _AUTOMATION_SYSTEM_PROMPT
         )
         if not exito:
@@ -226,3 +216,18 @@ class ServicioIA:
             "parametros": parametros,
             "respuesta_usuario": respuesta_usuario,
         }
+
+    def consultar(
+        self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
+    ) -> tuple[str, bool]:
+        return self._consultar_conversacion(mensaje, historial, _CHAT_SYSTEM_PROMPT)
+
+    def consultar_lite(
+        self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
+    ) -> tuple[str, bool]:
+        return self._consultar_conversacion(mensaje, historial, _SYSTEM_PROMPT)
+
+    def consultar_inteligente(
+        self, mensaje: str, historial: Optional[List[Dict[str, str]]] = None
+    ) -> Dict[str, Any]:
+        return self._consultar_automatizacion(mensaje, historial)

--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -25,6 +25,14 @@ servicio_ia = ServicioIA()
 logger = logging.getLogger(__name__)
 
 
+async def _consultar_api_lite(
+    mensaje: str, historial: Optional[List[Dict[str, str]]] = None
+) -> tuple[str, bool]:
+    """Envía la solicitud a la IA Lite sin disparar acciones locales."""
+
+    return await run_in_threadpool(servicio_ia.consultar_lite, mensaje, historial)
+
+
 class MensajeHistorial(BaseModel):
     rol: Literal["usuario", "asistente"]
     contenido: str = Field(..., min_length=1)
@@ -77,9 +85,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
     historial = req.historial
 
     try:
-        respuesta, exito = await run_in_threadpool(
-            servicio_ia.consultar_lite, mensaje, historial
-        )
+        respuesta, exito = await _consultar_api_lite(mensaje, historial)
         return ChatResponse(respuesta=respuesta, exito=exito)
     except Exception as exc:  # pragma: no cover - se devuelve error controlado
         logger.exception("Error procesando /api/chat: %s", exc)
@@ -92,8 +98,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
 @app.post("/api/chat-inteligente", response_model=SmartChatResponse)
 async def chat_inteligente(request: SmartChatRequest) -> SmartChatResponse:
     try:
-        respuesta, _ = await run_in_threadpool(
-            servicio_ia.consultar_lite,
+        respuesta, _ = await _consultar_api_lite(
             request.mensaje,
             [
                 {"rol": h.rol, "contenido": h.contenido} for h in request.historial or []
@@ -108,9 +113,7 @@ async def chat_inteligente(request: SmartChatRequest) -> SmartChatResponse:
 async def command(request: CommandRequest) -> CommandResponse:
     """Responde usando la IA sin ejecutar acciones locales."""
 
-    respuesta_ia, exito = await run_in_threadpool(
-        servicio_ia.consultar_lite, request.texto, None
-    )
+    respuesta_ia, exito = await _consultar_api_lite(request.texto, None)
     return CommandResponse(
         comando="sin_ejecucion",
         resultado=respuesta_ia,


### PR DESCRIPTION
## Summary
- Separate conversational and automation flows in `ServicioIA` to keep the Lite prompt isolated from command handling logic
- Centralize API endpoints on a shared Lite helper so responses only return generated text without triggering local actions

## Testing
- python -m pytest tests/test_ai_client.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbddeee0883329ee8f52eb981c9ca)