### PR TITLE
Clarify PROMPTY Lite separation from desktop actions

### DIFF
--- a/PROMPTY_3.0/ai/service.py
+++ b/PROMPTY_3.0/ai/service.py
@@ -1,4 +1,11 @@
-"""Cliente HTTP que delega llamadas al proveedor de IA."""
+"""Cliente HTTP para PROMPTY Lite.
+
+Este módulo se usa desde el servidor/API (PROMPTY Lite) únicamente para
+mantener una conversación textual. En esta edición no se ejecutan acciones
+locales ni comandos del sistema; las capacidades completas (abrir YouTube,
+gestionar carpetas, lanzar programas, etc.) siguen viviendo en el PROMPTY de
+escritorio y sus módulos de automatización.
+"""
 from __future__ import annotations
 
 import json
@@ -68,6 +75,10 @@ _DEFAULT_JSON_RESPONSE = {
 
 class ServicioIA:
     """Encapsula las llamadas HTTP hacia el proveedor de IA."""
+
+    # Este cliente HTTP se usa desde la API de PROMPTY Lite: solo conversa y
+    # nunca ejecuta acciones locales. Las acciones reales siguen viviendo en los
+    # módulos del PROMPTY de escritorio que interactúan con el sistema operativo.
 
     def __init__(self, config: Optional[IAConfig] = None, client: Optional[httpx.Client] = None):
         self.config = config or IAConfig.from_env()

--- a/PROMPTY_3.0/api/server.py
+++ b/PROMPTY_3.0/api/server.py
@@ -1,4 +1,10 @@
-"""API REST ligera para consumir las capacidades inteligentes de PROMPTY."""
+"""API REST ligera para consumir las capacidades inteligentes de PROMPTY.
+
+Esta API expone PROMPTY Lite: solo ofrece conversación con IA y nunca ejecuta
+acciones locales. El PROMPTY completo (aplicación de escritorio) mantiene las
+funciones de automatización como abrir YouTube, gestionar carpetas o lanzar
+programas. Aquí solo se delegan consultas textuales a la IA.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Documented in the API and IA client that PROMPTY Lite is conversational only and defers actions to the desktop edition
- Added inline comments reinforcing that action execution remains in the desktop modules

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbf69b700833297815fa3bf22795a)